### PR TITLE
docs: 登记 omdsh-dev/dsh-annotation 与 omdsh-dev/dsh-genui

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -10,6 +10,8 @@
 | dsh-artifact | [dsh-external/dsh-artifact](https://github.com/dsh-external/dsh-artifact) | 制品管理（运行级实测 ✅） |
 | dsh-split-panes | [dsh-external/dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) | 分屏面板（运行级实测 ✅） |
 | dsh-question-collapse | [dsh-external/dsh-question-collapse](https://github.com/dsh-external/dsh-question-collapse) | 问题折叠（运行级实测 ✅） |
+| dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） |
+| dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI 内联交互组件：dsh-ui fence 渲染图表/表单/测验/3D 场景，带 action 事件环 |
 
 <!-- 新增条目示例（复制下面一行修改后插入上表末尾）：
 | my-plugin | [dsh-external/my-plugin](https://github.com/dsh-external/my-plugin) | 一句话功能描述 |


### PR DESCRIPTION
<!--
  插件登记 PR 模板 —— 按此格式提交，合并后立即进入目录。
  目标文件：PLUGINS.md（表格追加一行即可）。
-->

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-annotation / dsh-genui |
| 仓库 | https://github.com/omdsh-dev/dsh-annotation · https://github.com/omdsh-dev/dsh-genui |
| 一句话说明 | 批注插件（选文字→批注→随消息发送，回复按 Annotation N 对照）；GenUI 内联交互组件（dsh-ui fence 渲染图表/表单/测验/3D 场景） |
| 版本 | 1.3.13 / 0.8.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope：`@dsh-external/dsh-annotation`、`@dsh-external/dsh-genui`
- [x] 仓库已打 `dsh-plugin` topic（两个仓库均含 `dsh-plugin`）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已按自检三步实测通过（本机 profile 实际运行中：批注流程 / dsh-ui fence 渲染均正常）

## 改动内容

PLUGINS.md 追加的两行：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） |
| dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI 内联交互组件：dsh-ui fence 渲染图表/表单/测验/3D 场景，带 action 事件环 |

## 备注

两个插件均为 omdsh-dev org 下公开仓库，当前在本机 web profile 作为官方 bundle 运行验证中。
