### PR TITLE
docs: add dsh-chat-import

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -22,6 +22,7 @@
 | dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） | 待测 |
 | dsh-security-scan | [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | Secret & dangerous-pattern scanner — API keys/tokens/private keys redacted; ignore lists; zero deps | 待测 |
 | dsh-turn-index | [Simon314620/dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 | 待测 |
+| dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-chat-import |
| 仓库 | https://github.com/Nwflower/dsh-chat-import |
| 一句话说明 | 从 Claude Code / Codex / ChatGPT 导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） |
| 版本 | 0.1.0（已发布 npm） |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-chat-import`（未占用 `@dsh-external/*` / `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明（`peerDependencies`: `@deepseek-ai/dsh-tools@0.1.0-rc.6`，host 提供）
- [x] 测试：`npm test` 35/35 通过；2026-08-13 于 dsh 0.1.0-rc.6 web profile 真实导入 Claude transcript → resume → 工作区归组（44 次 tool/call + tool/result 落盘、load OK）
- [x] 发布与加载自检：已发布 npm（`dsh-chat-import@0.1.0`）；`dsh plugin --profile headless add dsh-chat-import` 安装成功，headless 启动插件树加载无错误

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code / Codex / ChatGPT 导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |

## 备注

- 纯 Host 插件：无 Browser 侧、无 isolate realm；仅消费公开服务 sessionPersistence / fs / tools / workspaceRegistry。
- 欢迎雷达纳入 L2/L4 检查；如发现依赖声明或兼容性问题请指正。