### PR TITLE
docs: register four dsh plugins (telegram / scan / skills / webhook)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -35,7 +35,7 @@
 
 | 插件 | 仓库 | 说明 |
 |---|---|---|
-| （暂无手工登记；打标自动收录） | | |
+| dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps |
 
 ## 🛠 基础设施
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -18,6 +18,7 @@
 | dsh-tianshu-tui | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 的 TUI（终端界面） | 待测 |
 | dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI 内联交互组件：dsh-ui fence 渲染图表/表单/测验/3D 场景，带 action 事件环 | 待测 |
 | dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） | 待测 |
+| dsh-security-scan | [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | Secret & dangerous-pattern scanner — API keys/tokens/private keys redacted; ignore lists; zero deps | 待测 |
 
 ## 🧰 插件集
 
@@ -29,13 +30,14 @@
 
 | 插件 | 仓库 | 说明 |
 |---|---|---|
-| （暂无手工登记；打标自动收录） | | |
+| dsh-review-skills | [ben7am1n/dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | Engineering-discipline skill pack — code-review, simplify, plan-then-execute, test-first, resolve-conflict; bundled ctx.skills provider |
 
 ## 📡 远程渠道
 
 | 插件 | 仓库 | 说明 |
 |---|---|---|
 | dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps |
+| dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | Generic webhook receiver — POST /hook/:channel wakes per-channel dsh agents; Bearer auth, reply_url callbacks, 200/401/400/413 |
 
 ## 🛠 基础设施
 


### PR DESCRIPTION
Register four plugins across three categories:

- 📡 远程渠道: [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) — Telegram runtime adapter, per-chat sessions, allowlist auth, zero deps
- 🔌 单插件: [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) — secret & dangerous-pattern scanner, redacted findings, zero deps (19 tests)
- 🎓 技能: [ben7am1n/dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) — bundled skill provider (code-review/simplify/plan-then-execute/test-first/resolve-conflict), 8 tests
- 📡 远程渠道: [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) — generic webhook receiver, Bearer auth + reply_url callbacks (12 tests)

All four: topic dsh-plugin, verified against @deepseek-ai/dsh@0.1.0-rc.6 (install → layer mount → apply/effect/dispose green).