### PR TITLE
docs: add dsh-oauth-mcp-client

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -23,6 +23,7 @@
 | dsh-security-scan | [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | Secret & dangerous-pattern scanner — API keys/tokens/private keys redacted; ignore lists; zero deps | 待测 |
 | dsh-turn-index | [Simon314620/dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 | 待测 |
 | dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
+| dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-oauth-mcp-client |
| 仓库 | https://github.com/springbrand-lab/dsh-oauth-mcp-client |
| 一句话说明 | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已完成全新目录安装、单元测试、类型检查、构建和打包检查
- [x] 已在 DSH Web profile 加载并实际调用 `mcp__springbrand__search_capabilities` 成功

## 自检结果

`pnpm install`、`pnpm test`、`pnpm typecheck`、`pnpm build` 和 `pnpm pack --dry-run` 均通过。DSH Web 加载成功，生产 Springbrand MCP 的 capability 搜索工具调用正常。

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |