### PR TITLE
docs: add dsh-balance

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -24,6 +24,7 @@
 | dsh-turn-index | [Simon314620/dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 | 待测 |
 | dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
 | dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |
+| dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 字段 | 值 |
|---|---|
| 插件名 | dsh-balance |
| 仓库 | https://github.com/TwotwoPiggy/dsh-balance |
| 一句话说明 | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 |
| 版本 | 0.1.6 |

## 自检清单（提交前请确认）

- [x] package.json `name` 使用独立空间 `dsh-balance`（未占用 `@dsh-external/*` / `@deepseek-ai/*` 空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已完成全新目录安装、单元测试、类型检查、构建和打包检查
- [x] 已在真实环境自测通过，且已发布 npm：`dsh-balance@0.1.6`，通过 `dsh plugin --profile add dsh-balance` 安装正常。

## 目录改动

| 插件 | 仓库 | 说明 | 分类 |
|---|---|---|---|
| dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话消耗并显示账户余额 | 🔌 单插件 |

## 备注
- 已发布 npm
<img width="800" height="170" alt="image" src="https://github.com/user-attachments/assets/93a57173-f734-49b5-a50c-b1bd4b83cd51" />
