### PR TITLE
Register falsify-dsh

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -25,6 +25,7 @@
 | dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
 | dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |
 | dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 | 待测 |
+| falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | falsify-dsh |
| 仓库 | https://github.com/shi275773124/falsify-dsh |
| 一句话说明 | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing |
| 版本 | v0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用社区可控制命名空间 `falsify-dsh`（未占用 `@deepseek-ai/*`；也未占用 `@dsh-external/*`，因为没有该组织权限）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 运行时依赖已声明；`@deepseek-ai/dsh-tools` 由 DSH profile 提供，未发布到 npm，故不写成硬 peer
- [ ] 未做冻结 DSH SHA 的运行级加载实测。清单运行级标「待测」
- [x] 自检结果：`npm test` 7/7 通过（CLI 包装层）。缺少 CLI 返回 `CLI_ERROR`，不把 lint 绿升级成 claim-bearing PASS。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据。selftest ≠ claim-bearing |

## 备注

与 dsh-inspect 不同：inspect 是找茬/修复闭环，falsify-dsh 是默认 BLOCK 的裁决器，只包装公开 MIT CLI。