### PR TITLE
登记 billion-context-dsh

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -26,6 +26,7 @@
 | dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |
 | dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 | 待测 |
 | falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | 待测 |
+| billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | billion-context-dsh |
| 仓库 | https://github.com/Tyan66666/billion-context-dsh |
| 一句话说明 | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi |
| 版本 | 0.1.0（npm） |

## 自检清单

- [x] package.json `name` 使用自有命名空间（非 `@dsh-external/*`，未占用 `@deepseek-ai/*` 保留名）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 实测通过：已在本地 DSH web profile 完整验证——compress 触发 durable surface replace（compaction/start→summary→end）、nudge 按压力注入、decompress/search_context/acp_status 全部可用；25 个单元测试全绿

补充：仓库已打 `dsh-plugin` topic 且已发布 npm（billion-context-dsh@0.1.0），会被自动发现扫描收录；此 PR 仅为立即进入精选分类。