### PR TITLE
docs: 登记 deepseek-harness-desktop 桌面外壳

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -42,6 +42,7 @@
 | 插件 | 仓库 | 说明 |
 |---|---|---|
 | dsh-work | [vibeinging/dsh-work](https://github.com/vibeinging/dsh-work) | 以 dsh 为骨、codex 为皮的桌面 app | 待测 |
+| deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 | 待测 |
 
 ## ❓ 未分类
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | deepseek-harness-desktop |
| 仓库 | https://github.com/chyra-moon/deepseek-harness-desktop |
| 一句话说明 | Windows 原生桌面外壳:1:1 加载官方 Web UI,内置服务器托管、托盘驻留与掉线自动恢复 |
| 版本 | 0.1.0 |

## 自检清单(提交前逐项确认)

- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明(`dependencies` / `peerDependencies`,含 90+ 个 peer 依赖全部显式声明)
- [ ] package.json 使用 `@dsh-external/*` scope —— 不适用:本仓库不是 cordis 插件,是桌面外壳(与 `dsh-work`、`dsh-desktop-electron` 同类,登记在「基础设施」分类)
- [x] 验证:内置服务器与 npx 回退两种模式冒烟通过(`__DSH_BOOT__:true`);打包版与静默安装版冒烟均通过(结果落盘 smoke-result.json);本机日常实机运行正常

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 |

## 备注

- 雷达已可通过 `dsh-plugin` topic 自动发现;本 PR 为手工登记到「基础设施」分类。
- 项目 MIT 开源,安装包已发布为 GitHub Release v0.1.0(NSIS + portable)。
