### PR TITLE
docs: 登记 dsh-web-search-firecrawl 插件（Firecrawl 搜索提供方）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -27,6 +27,7 @@
 | dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 | 待测 |
 | falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | 待测 |
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
+| dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-web-search-firecrawl |
| 仓库 | https://github.com/yangzhe1003/dsh-web-search-firecrawl |
| 一句话说明 | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用用户 scope `@yangzhe1003/*`（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic（另有 `deepseek-harness`、`web-search`）
- [x] 所有运行时依赖已声明（peerDependencies：`@deepseek-ai/cordis`、`@deepseek-ai/dsh-web`、`@deepseek-ai/dsh-launch-environment`、`@deepseek-ai/dsh-invariants`；dependencies：`@deepseek-ai/schemastery`）
- [x] 已实测通过

**测试环境与结果**：本机 dsh web profile 安装 `@yangzhe1003/dsh-web-search-firecrawl@0.1.0`（`dsh plugin --profile web add @yangzhe1003/dsh-web-search-firecrawl`），`dsh --profile web --dump-config` 确认组合加载无报错且 `web` seam 已切换 `searchProvider: firecrawl`；重启后内置 `web_search` 工具经 Firecrawl 返回 5 条真实搜索结果（deepseek-code.com、reddit.com、github.com 等）。仓库自带 34 个单元测试 + 真实 API e2e（`tests/firecrawl.spec.ts`、`tests/firecrawl.e2e.ts`）全部通过。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-web-search-firecrawl | https://github.com/yangzhe1003/dsh-web-search-firecrawl | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） |

## 备注

- npm 包：`@yangzhe1003/dsh-web-search-firecrawl@0.1.0`，peer 依赖官方 `0.1.0-rc.6` 线（当前发布线）
- 运行级标 ✅：已在本机 harness（web profile）实测 `web_search` 返回真实结果
- scope 说明：目录约定建议 `@dsh-external/*`，本插件发布在用户 scope `@yangzhe1003/*`（与目录中 fuhefei/dsh-sentinel 等用户仓库先例一致），未占用 `@deepseek-ai/*` 保留命名空间
