### PR TITLE
登记申请:dsh-claude-move(Claude Code 会话迁移 + 技能迁移)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -15,6 +15,7 @@
 | dsh-split-panes | [dsh-external/dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) | 分屏面板 | ✅ |
 | dsh-question-collapse | [dsh-external/dsh-question-collapse](https://github.com/dsh-external/dsh-question-collapse) | 问题折叠 | ✅ |
 | dsh-sentinel | [fuhefei/dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) | 事件驱动唤醒 agent loop（文件/命令/http/进程/webhook 传感器） | 待测 |
+| dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | Claude Code 全量迁移+无缝续聊：会话导入/记忆/技能/CLAUDE.md 注入/续聊面板 | 待测 |
 | dsh-tianshu-tui | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 的 TUI（终端界面） | 待测 |
 | dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI 内联交互组件：dsh-ui fence 渲染图表/表单/测验/3D 场景，带 action 事件环 | 待测 |
 | dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） | 待测 |


### PR DESCRIPTION
插件登记申请 的 详细信息如下

## 登记信息

- 仓库:https://github.com/PerryLink/dsh-claude-move
- 描述:Claude Code 会话迁移+技能迁移--把会话/记忆(跨平台)转进/导出/CLAUDE.md 和settings 与全局指令,支持/resume-claude 续跑与 Web 可视化
- License:MIT;topic 已打 dsh-plugin。

## 自检(提交前自查)

- [x] 仓库公开 + dsh-plugin topic(含 dsh / deepseek-harness / claude-code / claude / migration / session-import / resume)
- [x] package.json:name / main / exports / dsh.bundle 齐全;并已按规范 peerDependencies 声明对齐(对 dsh 0.1.0-rc.6)
- [x] README 含 Overview / Compatibility / Install / Uninstall / Quick start / Configuration / Permissions & data / Troubleshooting / Development / License & security(五语:en/zh/es/pt/hi)
- [x] 许可证 MIT + THIRD_PARTY_NOTICES;含声明/全部依赖记录

## 实测环境与结果

- 环境:Windows 11 / Node 22 / @deepseek-ai/dsh@0.1.0-rc.6(2026-08-13 实测)
- 结果:
npm test 92/92 通过(node --test)
- 安装验证(临时 DSH_HOME,tarball 直装实测):
  - dsh plugin add -w <tarball> 后 --dump-config 见 # == dsh-claude-move 行;web 启动无 FAILED
  - 迁移会话 40 个 / 2387 个;跨平台同步 13/13 快照同步 13/13 迁移恢复与验证 true 全部通过
- 平台状态:Windows 已测;macOS/Linux 待测(README Compatibility 有说明)

如有疑问或需补充;请随时提出,我会及时更新