### PR TITLE
plugin: add dsh-test-runner

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -28,6 +28,7 @@
 | falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | 待测 |
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
+| dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
 
 ## 🧰 插件集
 
@@ -65,3 +66,4 @@
 <!-- 新增条目示例（复制下面一行修改后插入对应分类表格末尾）：
 | my-plugin | [你的账号/my-plugin](https://github.com/你的账号/my-plugin) | 一句话功能描述 | 待测 |
 -->
+


### PR DESCRIPTION
## dsh-test-runner

结构化测试运行工具 `test_run`：自动探测测试框架（vitest/jest/pytest/node:test/npm script），执行测试，解析出通过/失败统计与失败用例摘要，避免模型阅读整段原始测试输出。

### 分类
🔌 单插件（工具类）

### 仓库
- URL: https://github.com/suimi8/dsh-test-runner
- dsh-plugin topic: ✅
- License: MIT

### 兼容性证据
- mainline: 7b9644f（2026-08）
- 验证环境: Windows + PowerShell 执行器 + node:test 实测通过
- 依赖 seam: shell / fs / sandboxPolicy / ctx.tools（均为稳定 seam）
- 退化安全: 解析失败时退化为 exitCode + 输出尾部，不崩溃
- node --check index.js: 通过

### 规范合规
对照 docs/cookbook/adding-a-tool.md 与 docs/user/develop/ 全部 ✅（详见仓库 README「规范合规」一节）：
- execute 契约（canonical value / infra throw / exec.signal）
- UI 卡片硬规则（presentCall/presentResult 纯函数 / terminal title 是命令）
- 生命周期（effect-based 注册 / inject / isConcurrencySafe）
- 打包（dsh.bundle.patch / cordis.patch.yml 按包名引用）

### 变更
在「🔌 单插件」分类表格末尾追加一行。