### PR TITLE
docs: 登记 dsh-turn-index

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -26,6 +26,7 @@
 | dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
 | dsh-security-scan | [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | Secret & dangerous-pattern scanner — API keys/tokens/private keys redacted; ignore lists; zero deps | 待测 |
+| dsh-turn-index | [Simon314620/dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-turn-index |
| 仓库 | https://github.com/Simon314620/dsh-turn-index |
| 一句话说明 | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 为 `dsh-turn-index`（无 scope，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已开启 Allow edits from maintainers（PR 创建后勾选）
- [x] 所有运行时依赖已声明（react 为可选 peer；纯客户端插件，无运行时 npm 依赖）
- [x] 已按自检实测通过：

```bash
# npm 安装（Windows 11 · DSH 0.1.0-rc.6 · pnpm 11.21）
dsh plugin --profile web add dsh-turn-index   # 3 秒完成
dsh --profile web --dump-config               # 配置树可见挂载 ✓
```

- [x] 自检结果：web profile 挂载成功、侧边栏渲染正常；24 项边界单测（120 轮渲染 / 跳转命中与未命中 / 响应式 / 空态）与装配冒烟测试全部通过；宿主侧（Node）零运行时逻辑。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-turn-index | [Simon314620/dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 |

## 备注

- 纯客户端插件：不读写文件系统、无网络访问、无凭据接触；唯一落盘数据是浏览器 localStorage 中的 UI 偏好。
- 已知限制见仓库 README「已知限制」：跳转依赖 harness 聊天流的 DOM 契约（`data-chat-anchor-key` / `data-conversation-scroll`）；索引覆盖当前已加载的历史窗口，更早轮次需逐页加载。
- 运行级列暂标「待测」，欢迎维护者按 L4 流程运行实测后升级 ✅。
