### PR TITLE
收录 dsh-remote-sandbox（🛠 基础设施）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -52,6 +52,7 @@
 |---|---|---|
 | dsh-work | [vibeinging/dsh-work](https://github.com/vibeinging/dsh-work) | 以 dsh 为骨、codex 为皮的桌面 app | 待测 |
 | deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 | 待测 |
+| dsh-remote-sandbox | [weijiafu14/dsh-remote-sandbox](https://github.com/weijiafu14/dsh-remote-sandbox) | 生产级远程执行世界：E2B 沙箱内纯 JS sidecar，fs/subprocess 单次往返、进程输出有界、心跳保活、崩溃透明恢复（resume/recreate）、tar 工作区同步；修复官方 e2b POC 两处 host 假设。43 项测试（含 6 项真机 E2E）全绿 | 已测 |
 
 ## ❓ 未分类
 


### PR DESCRIPTION
在 🛠 基础设施 分类追加 [dsh-remote-sandbox](https://github.com/weijiafu14/dsh-remote-sandbox)。

**一句话**：把 E2B 执行世界做成生产可用 —— 补齐官方 `dsh-e2b` POC 明确留白的部分（沙箱只活 5 分钟、输出全留 host 内存、不同步 workspace）。

**能力**：沙箱内纯 JS sidecar 本地执行 fs/subprocess 原语，每个 fs 操作单次往返（官方 POC 每次变更 3–8 条 SDK 命令）；进程输出有界 + 可选 host spill（官方把整流留在 host 内存）；心跳保活；崩溃透明恢复（优先 resume 暂停沙箱、盘丢才 recreate + 从快照恢复 workspace）；tar 工作区 IN/OUT，`syncIn/syncOut` 可从 cordis.yml 覆盖。顺带修复 `tool-fs-search` 硬编码 host ripgrep 路径、沙箱权限模式在远程世界失效两处（见 deepseek-harness discussions #490）。

**测试**：37 项单测/provider 测试（真 sidecar bundle、真 dsh FileSystem/SubprocessRuntime 基类、keeper 生命周期/恢复/同步）+ 6 项真机 E2B E2E（保活/resume/recreate/大目录 grep 内存有界/tar 往返/自定义同步），全绿。

**运行级**：已测（本地单测 + 真机 E2E）。仓库已打 `dsh-plugin` topic。MIT。构建基线 `deepseek-harness@0.1.0-rc.6`。