### PR TITLE
docs: 登记 dsh-tray

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -10,6 +10,7 @@
 
 | 插件 | 仓库 | 说明 | 运行级 |
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
+| dsh-tray | [qing3a/dsh-tray](https://github.com/qing3a/dsh-tray) | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 | ✅ |
 |---|---|---|---|
 | chat-width | [dsh-external/chat-width](https://github.com/dsh-external/chat-width) | 终端宽度感知 | ✅ |
 | dsh-artifact | [dsh-external/dsh-artifact](https://github.com/dsh-external/dsh-artifact) | 制品管理 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-tray |
| 仓库 | https://github.com/qing3a/dsh-tray |
| 一句话说明 | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 |
| 版本 | 0.1.0 |

## 自检清单

- [x] package.json name 使用 @dsh-external scope
- [x] 仓库已打 dsh-plugin topic
- [x] 所有运行时依赖已声明
- [x] 运行时验证实测（本地 DSH 源码环境，2026-08-14）：**web + headless 双 profile 加载通过；win32 上 trayicon.exe 进程正常 spawn（单进程），首页 200；headless 无 webServer 时降级不崩**。验证方法见 https://github.com/deepseek-ai/deepseek-harness/discussions/462

## 改动内容
- PLUGINS.md 单插件表新增一行（运行级 ✅，基于本地运行时验证）
