### PR TITLE
docs: 登记 dsh-agent-message

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,6 +29,7 @@
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
+| dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一 DeepSeek Harness 进程里的不同 Agent 会话互相收发消息 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-agent-message |
| 仓库 | https://github.com/GengDaPeng/dsh-agent-message |
| 一句话说明 | 跨会话 Agent 通信：让运行在同一进程里的不同 Agent 会话互相收发消息 |
| 版本 | 1.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 为 `dsh-agent-message`（无 scope，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已开启 Allow edits from maintainers（`gh pr create` 默认允许维护者编辑，不传 `--no-maintainer-edit`）
- [x] 所有运行时依赖已声明（peerDependencies：`@deepseek-ai/cordis` ^4.0.1、`@deepseek-ai/dsh-tools` *）
- [x] 已按自检实测通过（第一手验证）：

```bash
# 安装
dsh plugin --profile web add github:GengDaPeng/dsh-agent-message
# 运行中的 web profile 已装本插件，本会话实际调用 list_peer_agents / send_agent_message 完成跨会话收发闭环
```

- [x] 自检结果：运行中的 web profile 已装本插件，`list_peer_agents` / `send_agent_message` 两个工具全局注册、跨会话收发闭环正常。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一进程里的不同 Agent 会话互相收发消息 |

## 备注

- 运行级列暂标「待测」，欢迎维护者按流程实测后升级 ✅。
- MIT 协议。
