### PR TITLE
docs: 登记 dsh-claude-move

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -34,6 +34,7 @@
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
 | dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一 DeepSeek Harness 进程里的不同 Agent 会话互相收发消息 | 待测 |
+| dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 从 Claude Code 全保真复制历史会话/记忆/技能/CLAUDE.md 到 DSH：可续聊会话按项目归入工作区，复制式增量同步（与运行中的 Claude Code 实时续写），Web 面板 + /claude-import-all + /resume-claude | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 登记信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-claude-move |
| 仓库 | https://github.com/PerryLink/dsh-claude-move |
| 一句话描述 | 把 Claude Code 的会话/记忆/技能/指令/CLAUDE.md 迁入 DSH:一键式迁移向导审批门控幂等,可断点续跑恢复,Web 界面 + /claude-import-all + /resume-claude |
| 版本 | 0.1.0 |

## 自检(提交前自查)

- [x] package.json `name` 无@ scope 为 dsh-claude-move(未用 @deepseek-ai/* 或 @dsh-external/* 命名空间)
- [x] 已打 dsh-plugin topic(含 dsh、claude-code、deepseek-harness、migration)
- [x] 本 PR 勾选 **Allow edits from maintainers**
- [x] 依赖声明符合规范(peerDependencies:@deepseek-ai/cordis、@deepseek-ai/dsh-tools@0.1.0-rc.6、@deepseek-ai/schemastery)
- [x] 真实执行自检通过:临时 web profile 启动无 FAILED + 类型检查/测试/构建/校验全绿(临时 DSH_HOME,对照 deepseek-harness checkout),npm test 100/100(GitHub Actions Node 22 实测)

## 登记表行

| 插件 | 仓库 | 描述 |
|---|---|---|
| dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 把 Claude Code 的会话/记忆/技能/指令/CLAUDE.md 迁入 DSH:一键式迁移向导审批门控幂等,可断点续跑恢复,Web 界面 + /claude-import-all + /resume-claude |

## 备注

- 许可 Apache-2.0(vendored MIT 来源记录 THIRD_PARTY_NOTICES 齐备);迁移无损(迁移后DSH 侧 append-only,可重跑/幂等)。
- 本地运行测试需要 DEEPSEEK_API_KEY 环境变量(RELEASE.md 有说明),未配置时跳过在线用例