### PR TITLE
docs: 登记 dsh-session-pins

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -35,6 +35,7 @@
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
 | dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一 DeepSeek Harness 进程里的不同 Agent 会话互相收发消息 | 待测 |
 | dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 从 Claude Code 全保真复制历史会话/记忆/技能/CLAUDE.md 到 DSH：可续聊会话按项目归入工作区，复制式增量同步（与运行中的 Claude Code 实时续写），Web 面板 + /claude-import-all + /resume-claude | 待测 |
+| dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## Summary
- 在 `PLUGINS.md` 的单插件分类登记 [`alooshxl/dsh-session-pins`](https://github.com/alooshxl/dsh-session-pins)。
- 标明该插件已在无凭据的真实 Web profile 中完成运行级验证，并如实记录 rc.6 无法通过公开 API 重新打开归档会话的限制。
- 该实现回应 [DeepSeek Harness Discussion #63](https://github.com/deepseek-ai/deepseek-harness/discussions/63)，仅使用公开的 `sidebar.footer.action` 插槽和客户端服务。

## 插件信息
| 项 | 值 |
|---|---|
| 插件名 | dsh-session-pins |
| 仓库 | https://github.com/alooshxl/dsh-session-pins |
| 一句话说明 | 在侧边栏持久置顶并快速打开可用普通会话；归档项可识别并移除 |
| 版本 | 0.1.0 |

## 自检清单
- [x] `package.json` 名称为 `@dsh-external/dsh-session-pins`
- [x] 仓库已添加 `dsh-plugin` topic
- [x] 所有运行时依赖与唯一 peer dependency 均已声明
- [x] 已发布 [`v0.1.0`](https://github.com/alooshxl/dsh-session-pins/releases/tag/v0.1.0)，安装命令为 `dsh plugin --profile web add github:alooshxl/dsh-session-pins#v0.1.0`
- [x] 允许维护者编辑此 PR

## Test plan
- [x] `python scripts/validate-catalog.py`
- [x] `make fmt && make test && make lint`（146 tests）
- [x] `pnpm run build && pnpm run verify:self-contained && pnpm run verify:package`
- [x] `@deepseek-ai/dsh@0.1.0-rc.6` 临时 `DSH_HOME`、离线安装、空工作区、根启动清单与真实浏览器模块路由验证
- [x] Windows 与 Ubuntu 24.04 验证；[`main` CI](https://github.com/alooshxl/dsh-session-pins/actions/runs/31743465224) 和 [`v0.1.0` CI](https://github.com/alooshxl/dsh-session-pins/actions/runs/31743636447) 均通过

## 改动内容
| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |

## 备注
DeepSeek Harness 0.1.0-rc.6 没有公开的归档会话恢复 API。插件会保留归档置顶项的标题和取消置顶操作，但不会显示无法完成的“打开”操作，也不会使用私有 API、宿主补丁或延时规避。