### PR TITLE
docs: 登记 dsh-cost-ledger

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,6 +29,7 @@
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
+| dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久化成本账本：监听 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方定价（可配置覆盖），暴露 record_cost/query_cost/set_budget 工具 + WebUI 仪表盘，DSH 0.1.0-rc.6 真实 LLM 流式已验证 | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-cost-ledger |
| 仓库 | https://github.com/suimi8/dsh-cost-ledger |
| 一句话说明 | 跨会话持久化成本账本：监听 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方定价（可配置覆盖），暴露 record_cost/query_cost/set_budget 工具 + WebUI 仪表盘 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用 `@deepseek-ai/*` 保留命名空间（使用无 scope 的 `dsh-cost-ledger`，非保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic（已验证：GitHub API `topic:dsh-plugin` 命中本仓库）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（提交后已通过 `gh pr edit --enable-maintainer-collaboration` 开启）
- [x] 所有运行时依赖已声明（`dependencies`: better-sqlite3；`peerDependencies`: @deepseek-ai/cordis、@deepseek-ai/dsh-settings、schemastery。react/react-dom 与 @deepseek-ai/dsh-client-* 为 host 模块加载器运行时提供的 external，已正确声明为 devDependencies/peerDependencies，不打包进 client bundle）
- [x] 已按自检三步实测通过：

```bash
# 1. 加载最新 dsh 并加载插件 —— 已在 ~/.dsh/profiles/headless 与 web 通过 dsh plugin --profile <p> add . 安装并 link
# 2. 加载级：dsh web 启动后 apply() 运行、SQLite 打开，无报错（README Status 表「Live load in dsh web」✅ verified）
# 3. 端到端：dsh --profile headless "reply with exactly: hi" → 真实 LLM 调用 → llm/stream 监听器触发 → usage chunk 提取 → SQLite 写入真实行（{model, inputTokens, outputTokens, cacheReadTokens}）
```

- [x] 自检结果：
  - `pnpm selftest` —— 28/28 数据层检查全过（store 记录/汇总/预算/渲染）
  - `pnpm typecheck` —— 通过（strict: true + noImplicitAny）
  - `pnpm build` —— 通过（host lib/*.js + client lib/client.js 60.8kb）
  - 真实 LLM 流式验证（DSH 0.1.0-rc.6，2026-08-13）：headless 一次性调用产生 ledger.db 真实行，llm/stream → usage → SQLite 全链路打通
  - 运行环境：Windows 11 / Node v22.20.0 / pnpm 10.32.1

## 改动内容

PLUGINS.md 在 `## 🔌 单插件` 表格末尾追加一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久化成本账本：监听 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方定价（可配置覆盖），暴露 record_cost/query_cost/set_budget 工具 + WebUI 仪表盘，DSH 0.1.0-rc.6 真实 LLM 流式已验证 | ✅ |

## 备注

- 已验证证据等级对应 README「本仓库如何判定」L3（运行时实测 + 真实 provider 调用），故运行级标 ✅。
- README 已按「一个合格的插件 README 至少包含」补齐 Compatibility / Install / Uninstall / Quick start / Configuration / Permissions & data / Troubleshooting / Development / License & security 全部章节。
- 客户端 bundle 把 react/react-dom 与 dsh-client-* runtime 作为 external（host 模块加载器运行时解析），仅 better-sqlite3 为运行时 dependency。