### PR TITLE
docs: 登记 dsh-cost-ledger

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -36,6 +36,7 @@
 | dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一 DeepSeek Harness 进程里的不同 Agent 会话互相收发消息 | 待测 |
 | dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 从 Claude Code 全保真复制历史会话/记忆/技能/CLAUDE.md 到 DSH：可续聊会话按项目归入工作区，复制式增量同步（与运行中的 Claude Code 实时续写），Web 面板 + /claude-import-all + /resume-claude | 待测 |
 | dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |
+| dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
> 📌 标题格式 `docs: 登记 dsh-cost-ledger`，已按模板要求。
> 🛠 Allow edits from maintainers 已在本 PR 右侧勾选（`maintainer_can_modify=true`），维护者可帮忙 rebase。

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-cost-ledger |
| 仓库 | https://github.com/suimi8/dsh-cost-ledger |
| 一句话说明 | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价，提供 record_cost/query_cost/set_budget 工具 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] 包名 `dsh-cost-ledger` 使用个人命名空间 `suimi8/*`（未占用 `@deepseek-ai/*` 保留命名空间）。注：模板第 1 条建议 `@dsh-external/*`，但 README 正文明确"只有获得 dsh-external 维护权限的项目才应使用 `@dsh-external/*`"，本仓库属个人账号，故用个人命名空间，符合 README 规范。
- [x] 仓库已打 `dsh-plugin` topic（topics: cost-ledger, deepseek, deepseek-harness, dsh-plugin, token-usage）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（`maintainer_can_modify=true`）
- [x] 所有运行时依赖已声明：`dependencies: better-sqlite3`；`peerDependencies: @deepseek-ai/cordis、@deepseek-ai/dsh-settings、schemastery`
- [x] 已按自检三步实测通过：

### 自检结果

按模板"自检三步"在真实 DSH 0.1.0-rc.6 上验证：

1. **加载级**：`dsh plugin --profile web add .` 安装 → host 从 `package.json` 的 `dsh.bundle.patch` 发现插件 → 加载 `lib/index.js` → `apply()` 运行 → SQLite 在 `dsh-cost-ledger/ledger.db` 打开。无报错。
2. **加载级（headless）**：`dsh --profile headless` 下插件同样加载（HTTP API/dashboard 为 web-profile-only，headless 静默跳过）。
3. **运行级（端到端 token 捕获）**：`dsh --profile headless "reply with exactly: hi"` → 真实 LLM 调用 → `llm/stream` 监听器（`{ global: true }`）触发 → usage chunk 采集 → SQLite 写入真实行（`{model:"glm-5-2", inputTokens, outputTokens, cacheReadTokens}`）。完整 `llm/stream → usage-chunk → SQLite` 管线经真实 host 验证。

数据层另通过 `pnpm selftest`（43 项断言）覆盖 store + pricing + tool 端到端；`pnpm typecheck` + `pnpm build` 通过。

### 关于依赖声明

模板自检脚本提示"声明所有运行时依赖（react 等）到 package.json dependencies"。本插件的 react/react-dom 与 `@deepseek-ai/dsh-client-*` 为 **client bundle 外部依赖**（运行时由 host 的模块加载器解析），已正确声明为 `devDependencies`/`peerDependencies` 而非 `dependencies`——这是 DSH 客户端插件的标准做法（host 注入，避免重复打包）。唯一运行时 `dependency` 是 `better-sqlite3`（含 win32 预编译二进制）。

## 改动内容

PLUGINS.md 追加的行（🔌 单插件表，紧接 dsh-test-runner 之后）：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 |

运行级填 **待测**——未经本雷达 mainline 兼容性四维扫描；维护者自动扫描可按 SOP 移至 ✅/关注/需适配。

## 备注

- **DSH 版本**：验证锚定 `0.1.0-rc.6`（`ctx.on('llm/stream')`、`ctx.tools.register`、`ctx.inject`、`agentDefaultModel` API 形状已对照 `deepseek-ai/deepseek-harness` master 源码确认）。DSH 仍处开发者预览，未来 mainline 可能重命名接口，届时需插件更新。
- **平台**：SQLite 后端通过 `better-sqlite3` 附带 win32 预编译二进制，无需 C++ 工具链；其它平台安装时从源码编译。已验证 Windows 11 / Node 22。
- **想被雷达重点跟踪的维度**：`llm/stream` 事件签名、`ctx.tools.register` 的 `ToolDefinition.output` 契约、`webServer.register({kind, path, handler})` 路由 API——这三个若在 mainline 漂移会直接断插件。
- **安全面**：无网络出站、不存储任何凭证；仅读取 host 在 `llm/stream` 事件上已发出的 token 计数与模型名。HTTP API 写端点（cleanup/config/parse-prices）有同源校验。