### PR TITLE
docs: 登记 dsh-calendar / dsh-dingtalk / dsh-slack 三个新插件

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -23,6 +23,9 @@
 | dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） | 待测 |
 | dsh-security-scan | [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | Secret & dangerous-pattern scanner — API keys/tokens/private keys redacted; ignore lists; zero deps | 待测 |
 | dsh-email | [STARDUSTLC666/dsh-email](https://github.com/STARDUSTLC666/dsh-email) | 邮件工具插件：IMAP/SMTP 收/发/搜/列文件夹/附件下载（email_list/read/search/send/folders/attachment），内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，支持多账号与连接复用，发信默认走审批门；纯 Node 全平台 | 待测 |
+| dsh-calendar | [STARDUSTLC666/dsh-calendar](https://github.com/STARDUSTLC666/dsh-calendar) | CalDAV 日历插件：查/建/改/删/搜日程（calendar_list/create/update/delete/search），Google/iCloud/Nextcloud/自定义端点，应用专用密码 | 待测 |
+| dsh-dingtalk | [STARDUSTLC666/dsh-dingtalk](https://github.com/STARDUSTLC666/dsh-dingtalk) | 钉钉群机器人通知（dingtalk_notify/dingtalk_text），自定义机器人 webhook+加签，零运行时依赖 | 待测 |
+| dsh-slack | [STARDUSTLC666/dsh-slack](https://github.com/STARDUSTLC666/dsh-slack) | Slack 通知插件（slack_notify/slack_channels），Bot Token + 官方 Web API | 待测 |
 | dsh-turn-index | [Simon314620/dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) | 对话轮次索引侧边栏：每轮提问一目了然，点击跳转 + 滚动联动高亮，双语纯客户端 | 待测 |
 | dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
 | dsh-sticky-note | [Meredith2328/dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) | 输入框工具栏快速便签：点子/感想/TODO，Markdown 预览、自动保存、一键发送、保留与自动清除 | 待测 |


### PR DESCRIPTION
三个新社区插件（作者 stardustlc，均打 dsh-plugin 话题，GitHub Actions 测试绿）：

1. **dsh-calendar** — CalDAV 日历：calendar_list/create/update/delete/search 五工具，Google/iCloud/Nextcloud/自定义端点，应用专用密码。npm: dsh-calendar（发布中）
2. **dsh-dingtalk** — 钉钉群通知：dingtalk_notify/dingtalk_text，自定义机器人 webhook+HMAC 加签，零运行时依赖。npm: https://www.npmjs.com/package/dsh-dingtalk
3. **dsh-slack** — Slack 通知：slack_notify/slack_channels，官方 Web API。npm: https://www.npmjs.com/package/dsh-slack

三者均遵守社区约定：parameters 编译为原生 JSON Schema、dsh.bundle.patch 清单完整、全中文错误、配置缺失不崩启动。