### PR TITLE
docs: 登记 dsh-mdbox

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -42,6 +42,7 @@
 | dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 从 Claude Code 全保真复制历史会话/记忆/技能/CLAUDE.md 到 DSH：可续聊会话按项目归入工作区，复制式增量同步（与运行中的 Claude Code 实时续写），Web 面板 + /claude-import-all + /resume-claude | 待测 |
 | dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |
 | dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 | 待测 |
+| dsh-mdbox | [Chi-hong22/dsh-mdbox](https://github.com/Chi-hong22/dsh-mdbox) | DSH Web 输入框 Markdown 编辑辅助：Shift+Enter 列表续行与空项退出、有序列表自动重编号、Tab/Shift+Tab 双向缩进；纯客户端零运行时依赖，不碰文件/网络/凭据 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-mdbox |
| 仓库 | https://github.com/Chi-hong22/dsh-mdbox |
| 一句话说明 | DSH Web 输入框 Markdown 编辑辅助：列表续行、自动重编号、Tab 缩进 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `@chi-hong22/dsh-mdbox`（未占用 `@deepseek-ai/*` 保留命名空间；README 最低条件允许非 dsh-external 命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies: @deepseek-ai/cordis ^4.0.1`；纯客户端插件无其他运行时依赖）
- [x] 已按自检三步实测通过（Windows 环境，等效流程）：

```powershell
dsh plugin --profile mdbox-check add <本地工作区>
dsh --profile mdbox-check --dump-config
```

输出（dsh 0.1.0-rc.6，2026-08-14）：

```yaml
# == @chi-hong22/dsh-mdbox
- id: ui-mdbox
  name: '@chi-hong22/dsh-mdbox'
```

- [x] 自检结果：加载级通过（挂载成功无报错）；功能级实机验证见仓库 README「Compatibility」（0.1.0-rc.6，2026-08-13）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-mdbox | [Chi-hong22/dsh-mdbox](https://github.com/Chi-hong22/dsh-mdbox) | DSH Web 输入框 Markdown 编辑辅助插件 |

## 备注

- 纯浏览器端客户端插件（`dsh.client` platform=web），宿主半部为空实现；按键行为全部在 textarea 层完成，发出去的内容仍是纯文本。
- 风险披露：不访问文件/网络/凭据，不持久化数据；副作用挂 Cordis fiber，停用即还原（详见 README「Permissions & data」）。
- 运行级列暂填「待测」，请雷达按例实测后更新。