### PR TITLE
docs: 登记 vpshub

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -43,6 +43,7 @@
 | dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |
 | dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 | 待测 |
 | dsh-mdbox | [Chi-hong22/dsh-mdbox](https://github.com/Chi-hong22/dsh-mdbox) | DSH Web 输入框 Markdown 编辑辅助：Shift+Enter 列表续行与空项退出、有序列表自动重编号、Tab/Shift+Tab 双向缩进；纯客户端零运行时依赖，不碰文件/网络/凭据 | 待测 |
+| vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;可选设置页 UI(真实会话闭环实测:发现/连接/增删/别名预填) | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | vpshub |
| 仓库 | https://github.com/Sdongmaker/vpshub |
| 一句话说明 | DSH 的 VPS Hub:本地 SSH 台账 + vps_* 工具让 AI 发现/测试/执行/传输服务器,密钥仅路径引用,可选设置页 UI |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope —— **未采用**:包名为无 scope 的 `dsh-vps-hub`(与 `@deepseek-ai/*` 保留命名空间不冲突;无 scope 命名与目录中多个既有条目一致)。如需 `@dsh-external/*` 约定,可后续发布时调整
- [x] 仓库已打 `dsh-plugin` topic(另附 deepseek-harness / cordis / ssh / vps)
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**(gh pr create --maintainer-can-modify)
- [x] 所有运行时依赖已声明:`peerDependencies`(@deepseek-ai/cordis、@deepseek-ai/dsh-tools)+ `dependencies`(zod)
- [x] 已按自检三步实测通过 —— **补充**:未使用 headless --patch 加载流程,但已在**真实 DSH Web 会话**中完成运行级验证:
  1. 动态插件版:8 个 vps_* 工具注册并端到端实测(导入 ~/.ssh/config → 添加 → 列表+状态 → 连通测试 → 远程执行 → scp 上传/下载 → 删除,真实服务器)
  2. 设置页 UI:Settings → VPS Hub 全流程闭环(发现服务器卡片 → 测试连接实时更新 lastSeenAt → 添加/删除含 confirm → ~/.ssh/config 别名下拉预填带"已在台账"标记)
  3. 发布包版:`node examples/smoke.mjs` 冒烟测试通过(工具注册、真实台账读取、只读远程执行)

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;可选设置页 UI(真实会话闭环实测:发现/连接/增删/别名预填) |

## 备注

- 存储对标 Orca 的 SshTarget 模型:`source: 'ssh-config' | 'manual'`、删除 tombstone、别名抑制;密钥仅存 identityFile 路径,内容不出本机
- 设置页 UI 目前以 `examples/dynamic-plugin/`(动态插件)形式提供,正式包内置 client 需 Typert Remote 管线,计划后续版本
- 支持 macOS/Linux,私钥认证;Windows 与密码认证暂不支持
