### PR TITLE
docs: 登记 dsh-bash-terminal

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -12,6 +12,7 @@
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
 | dsh-tray | [qing3a/dsh-tray](https://github.com/qing3a/dsh-tray) | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 | ✅ |
 |---|---|---|---|
+| dsh-bash-terminal | [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) | Windows 三终端 shell 工具（PowerShell/Git Bash/WSL，默认终端由用户在设置中选择）+ 交互式 PTY 终端 + 官方沙箱对接；4 套件测试 + GitHub Actions CI 全绿 | ✅ |
 | chat-width | [dsh-external/chat-width](https://github.com/dsh-external/chat-width) | 终端宽度感知 | ✅ |
 | dsh-artifact | [dsh-external/dsh-artifact](https://github.com/dsh-external/dsh-artifact) | 制品管理 | ✅ |
 | dsh-split-panes | [dsh-external/dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) | 分屏面板 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-bash-terminal |
| 仓库 | https://github.com/MAXeaglet/dsh-bash-terminal |
| 一句话说明 | Windows 三终端 shell 工具（PowerShell/Git Bash/WSL，默认终端由用户在设置中选择）+ 交互式 PTY 终端 + 官方沙箱对接 |
| 版本 | 0.3.14 |

## 自检清单

- [x] package.json name 使用自有命名空间（dsh-bash-terminal，未占用 @deepseek-ai/* 保留命名空间）
- [x] 仓库已打 dsh-plugin topic
- [x] 所有运行时依赖已声明（peerDependencies 12 项：@deepseek-ai/cordis + dsh 包 + react；dependencies: schemastery）
- [x] 自检实测通过：官方 dsh.bundle manifest（profile bundles 自动挂载，dump-config 验证）；4 套件测试（unit/apply/client/real-node-pty PTY）全绿；GitHub Actions CI（windows-latest）通过；独立实例加载零错误

## 改动内容

PLUGINS.md 追加一行（🔌 单插件，运行级 ✅）：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-bash-terminal | MAXeaglet/dsh-bash-terminal | Windows 三终端 shell 工具 + 交互式 PTY + 官方沙箱 |

## 备注

npm 已发布（dsh-bash-terminal，latest 0.2.3；0.3.x 待 2FA 补发）。