### PR TITLE
docs: 登记 dsh-latexcp

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -44,6 +44,7 @@
 | dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 | 待测 |
 | dsh-mdbox | [Chi-hong22/dsh-mdbox](https://github.com/Chi-hong22/dsh-mdbox) | DSH Web 输入框 Markdown 编辑辅助：Shift+Enter 列表续行与空项退出、有序列表自动重编号、Tab/Shift+Tab 双向缩进；纯客户端零运行时依赖，不碰文件/网络/凭据 | 待测 |
 | vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;可选设置页 UI(真实会话闭环实测:发现/连接/增删/别名预填) | ✅ |
+| dsh-latexcp | [Chi-hong22/dsh-latexcp](https://github.com/Chi-hong22/dsh-latexcp) | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式复制按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式 | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-latexcp |
| 仓库 | https://github.com/Chi-hong22/dsh-latexcp |
| 一句话说明 | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式浮现按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式，行内/行间自动匹配定界符） |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 为 `@chi-hong22/dsh-latexcp`（个人可控 scope，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明：无 `dependencies`，`peerDependencies` 仅 `@deepseek-ai/cordis ^4.0.1`
- [x] 已按自检步骤实测通过（纯浏览器端插件，加载级用 web profile 验证；模板里的 headless 三步针对宿主半部插件，本插件宿主半部为空实现）：

```bash
# 1. 安装并加载（web profile）
dsh plugin --profile web add github:chi-hong22/dsh-latexcp
# 2. 确认挂载行存在、无报错
dsh --profile web --dump-config | Select-String ui-latexcp
# 3. 纯函数回归（Node，无需浏览器）
node .scratch/latexcp/verify.mjs
```

- [x] 自检结果贴这里：`dump-config` 输出包含 `ui-latexcp` 挂载行（`# == @chi-hong22/dsh-latexcp`），无报错；浏览器端手动验证（`@deepseek-ai/dsh-*` 0.1.0-rc.6 npx 快照，2026-08-15）：悬停公式浮现按钮、美元/斜杠两种格式复制、行内/行间定界符自动匹配、菜单切换默认格式、「✓ 已复制」后可连续复制、停用插件后按钮与样式全部还原，逐项通过；`verify.mjs` 纯函数回归通过。

## 改动内容
|插件|仓库|说明|
|---|---|---|
| dsh-latexcp | [Chi-hong22/dsh-latexcp](https://github.com/Chi-hong22/dsh-latexcp) | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式浮现按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式，行内/行间自动匹配定界符） | 待测 |

## 备注

- 纯浏览器端插件：无宿主半部、无服务注入；复制走 `navigator.clipboard`，不碰文件、网络与用户数据。
- 实现依赖 KaTeX 渲染 DOM 保留的 `.katex-mathml` annotation 节点与 `.katex-display` 行间标记；DSH 若调整 Markdown/KaTeX 渲染 DOM 需跟随适配。
- 兼容性：已在 `@deepseek-ai/dsh-*` 0.1.0-rc.6（npx 部署快照）上验证，最后验证日期 2026-08-15。
- 许可证：MIT。