### PR TITLE
docs: 登记 dsh-plugin-web-access

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -45,6 +45,7 @@
 | dsh-mdbox | [Chi-hong22/dsh-mdbox](https://github.com/Chi-hong22/dsh-mdbox) | DSH Web 输入框 Markdown 编辑辅助：Shift+Enter 列表续行与空项退出、有序列表自动重编号、Tab/Shift+Tab 双向缩进；纯客户端零运行时依赖，不碰文件/网络/凭据 | 待测 |
 | vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;可选设置页 UI(真实会话闭环实测:发现/连接/增删/别名预填) | ✅ |
 | dsh-latexcp | [Chi-hong22/dsh-latexcp](https://github.com/Chi-hong22/dsh-latexcp) | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式复制按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式 | 待测 |
+| dsh-plugin-web-access | [junhongchashui/dsh-plugin-web-access](https://github.com/junhongchashui/dsh-plugin-web-access) | 纯本地按需网页访问：web_fetch 命令行抓取 + 无头浏览器（browser_open/snapshot/eval/screenshot）双通道，零 API Key，注册 ctx.web fetch provider | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-web-access |
| 仓库 | https://github.com/junhongchashui/dsh-plugin-web-access |
| 一句话说明 | 纯本地按需网页访问：web_fetch 命令行抓取 + 无头浏览器（browser_open/snapshot/eval/screenshot）双通道，零 API Key，注册 ctx.web fetch provider |
| 版本 | 0.1.0 |

## 自检清单

- [x] package.json name 使用自有命名空间（未占用 @deepseek-ai/* 保留命名空间）
- [x] 仓库已打 dsh-plugin topic
- [x] 已允许维护者编辑（maintainer_can_modify=true）
- [x] 所有运行时依赖已声明（playwright-core ^1.45.0）
- [x] 已实测：Windows 11 + Node v24 + DSH 0.1.0-rc.6，动态插件加载成功，web_fetch 与浏览器四工具调用正常

## 改动内容

PLUGINS.md「🔌 单插件」表格追加一行：dsh-plugin-web-access（junhongchashui/dsh-plugin-web-access）

## 备注

- 与官方 @deepseek-ai/dsh-tool-web 在 fetchEnabled 启用时的 web_fetch 工具同名互斥（二选一），README 兼容性章节已注明。
- MIT 许可，README 含安装/卸载/配置/示例/兼容性声明。