### PR TITLE
docs: 登记 ds-api-usage

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -25,6 +25,7 @@
 | dsh-chat-import | [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code JSONL 全保真导入历史会话为可续聊的 DSH 会话（含工具调用/思考块） | 待测 |
 | dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |
 | dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 | 待测 |
+| ds-api-usage | [Sev7een/ds-api-usage](https://github.com/Sev7een/ds-api-usage) | 在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线 | 待测 |
 | falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | 待测 |
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | ds-api-usage |
| 仓库 | https://github.com/Sev7een/ds-api-usage |
| 一句话说明 | 在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] `package.json` 名称为 `dsh-plugin-ds-api-usage`，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已添加 `dsh-plugin` topic
- [x] 已允许维护者编辑 PR 分支
- [x] `package.json` 已声明 `dsh.bundle`、`dsh.client`、Host 与 Client 导出；无未声明的第三方运行时依赖
- [x] 已运行插件语法检查并验证 web profile 组合加载

```bash
npm run check
dsh --profile web --dump-config
dsh web
```

- [x] 自检结果：`npm run check` 通过；dump-config 包含 `# == dsh-plugin-ds-api-usage` 与 `id: ds-api-usage`；DSH Web 启动后返回 HTTP 200

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| ds-api-usage | [Sev7een/ds-api-usage](https://github.com/Sev7een/ds-api-usage) | 在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线 | 待测 |

## 备注

- 余额读取需要 DSH 已配置 `DEEPSEEK_API_KEY`，Host 环境需提供 `curl`。
- 用量统计保存在内存中，插件重启后重新累计。
- 许可证：MIT。
