### PR TITLE
docs: 登记 dsh-lark-bot

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -48,6 +48,7 @@
 |---|---|---|
 | dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps |
 | dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | Generic webhook receiver — POST /hook/:channel wakes per-channel dsh agents; Bearer auth, reply_url callbacks, 200/401/400/413 |
+| dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | Feishu / Lark bridge for DeepSeek Harness — streaming cards, git-worktree project isolation, official dsh SDK/ACP backends, approval & Q&A cards, SECURITY.md |
 
 ## 🛠 基础设施
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-lark-bot |
| 仓库 | https://github.com/PlutoKeating/dsh-lark-bot |
| 一句话说明 | Feishu / Lark bridge for DeepSeek Harness — streaming cards, git-worktree project isolation, official dsh SDK/ACP backends, approval & Q&A cards, SECURITY.md |
| 版本 | 0.3.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用**自有命名空间** `dsh-lark-bot`（未占用 `@dsh-external/*` 或 `@deepseek-ai/*` 保留命名空间；与已收录的 dsh-telegram / dsh-webhook-bridge 同为独立桥接项目）
- [x] 仓库已打 `dsh-plugin` topic（另有 `deepseek` / `deepseek-harness` / `feishu` / `lark` / `bridge` / `chatbot` / `messaging` / `bot` / `typescript` / `dsh`）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`dependencies`：`@deepseek-ai/dsh-sdk-client`、`@agentclientprotocol/sdk`、`@larksuite/channel`、`commander` 等）
- [x] 自检实测：本项目为**非 cordis 插件形态的桥接 bot**，以官方 runtime profile 方式接入 dsh（`dsh-base` + `dsh-sdk-jsonrpc-server` / `dsh-acp`）。已在 **dsh 0.1.0-rc.6** 上完成 SDK JSON-RPC / ACP `initialize` 握手与真实任务流式验证（2026-08-14，见仓库 `docs/adapter-notes.md` 与 `SECURITY.md`）。自检命令与模板面向 cordis 插件的 `dsh --patch` 加载路径不同，特此说明。

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-lark-bot | https://github.com/PlutoKeating/dsh-lark-bot | Feishu / Lark bridge — streaming cards, git-worktree isolation, official dsh SDK/ACP backends, approval & Q&A cards |

## 备注

- 形态说明：非 cordis 插件，属于「📡 远程渠道」桥接项目（与 dsh-telegram 同类）；npm 双包 `dsh-lark-bot` / `dsh-feishu-bot` 已发布 0.3.0。
- 兼容性：已验证 dsh 0.1.0-rc.6（2026-08-14）；默认 adapter 为官方 SDK client（原生 session + 流式 thinking/text），`DSH_LARK_ADAPTER=acp` 提供审批卡。
- 已知边界：ACP 会话为全新会话（上游限制）；SDK 协议无 mid-turn cancel，`/stop` 会关闭对应 runtime 并自动重启。
