### PR TITLE
docs: 登记 dsh-stream-rules

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,7 +29,7 @@
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
-| dsh-stream-rules | [jiesou/dsh-stream-rules](https://github.com/jiesou/dsh-stream-rules) | 需要时注入规则、不浪费上下文（opencode-stream-rules 的 DSH 移植） | 待测 |
+| dsh-stream-rules | [jiesou/dsh-stream-rules](https://github.com/jiesou/dsh-stream-rules) | 模式匹配自动注入 steering rules，不占系统上下文 | 待测 |
 
 ## 🧰 插件集
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,7 +29,7 @@
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
-| dsh-stream-rules | [jiesou/dsh-stream-rules](https://github.com/jiesou/dsh-stream-rules) | 需要时注入规则、不浪费上下文；opencode-stream-rules 的 DSH 移植（npm @jiesou/dsh-stream-rules） | 待测 |
+| dsh-stream-rules | [jiesou/dsh-stream-rules](https://github.com/jiesou/dsh-stream-rules) | 需要时注入规则、不浪费上下文（opencode-stream-rules 的 DSH 移植） | 待测 |
 
 ## 🧰 插件集
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,6 +29,7 @@
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
+| dsh-stream-rules | [jiesou/dsh-stream-rules](https://github.com/jiesou/dsh-stream-rules) | 需要时注入规则、不浪费上下文；opencode-stream-rules 的 DSH 移植（npm @jiesou/dsh-stream-rules） | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
<!--
  插件登记 PR —— 按官方模板填写，参考已合并 PR（如 #28 dsh-mdbox）的写法。
-->

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-stream-rules |
| 仓库 | https://github.com/jiesou/dsh-stream-rules |
| 一句话说明 | 模式匹配自动注入 steering rules，不占系统上下文 |
| 版本 | 0.1.6 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `@jiesou/dsh-stream-rules`（未占用 `@deepseek-ai/*` 保留命名空间；README 最低条件允许非 dsh-external 命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（或已在 fork Settings → General 开启同项，一次开启后续自动生效）
- [x] 所有运行时依赖已声明（`peerDependencies: @deepseek-ai/cordis`；`dependencies: @deepseek-ai/dsh-llm / dsh-tools / schemastery`）
- [x] 已按自检实测通过（Linux，dsh 0.1.0-rc.6）：

```bash
dsh plugin --profile stream-rules-check add @jiesou/dsh-stream-rules
dsh --profile stream-rules-check --dump-config
```

输出（`dsh --profile stream-rules-check --dump-config`）：

```yaml
# == @jiesou/dsh-stream-rules
- id: stream-rules
  name: '@jiesou/dsh-stream-rules'
```

- [x] 自检结果：npm 安装成功、配置层已应用、headless 启动、规则触发验证

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-stream-rules | [jiesou/dsh-stream-rules](https://github.com/jiesou/dsh-stream-rules) | 模式匹配自动注入 steering rules，不占系统上下文 |

## 备注

- 纯后端 bundle 插件（无 `dsh.client`）：钩官方 `tools/pre-execute` 瀑布（`reject` 拦首次调用）与 `agent.inject()`（非唤醒注入）。
- https://github.com/jiesou/dsh-stream-rules README 已经说明了用法，很清晰。
- 运行级列暂填「待测」，请雷达按例实测后更新。
