### PR TITLE
docs: add dsh-plugin-cost to plugin registry

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -29,6 +29,7 @@
 | billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | 待测 |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
+| dsh-plugin-cost | [yweilai77-dev/dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost) | DSH Web 会话费用估算：tokenUsage 四桶 × 可配置价格表，一键刷新官方价格（估算非账单） | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
Add dsh-plugin-cost (Web UI ??) to PLUGINS.md per the submission flow. Repo is tagged `dsh-plugin` for auto-discovery. Bundle-format package; install via `dsh plugin add github:yweilai77-dev/dsh-plugin-cost`.