### PR TITLE
docs: 登记 dsh-plugin-installer

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -41,6 +41,7 @@
 | 插件 | 仓库 | 说明 |
 |---|---|---|
 | dsh-review-skills | [ben7am1n/dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | Engineering-discipline skill pack — code-review, simplify, plan-then-execute, test-first, resolve-conflict; bundled ctx.skills provider |
+| dsh-plugin-installer | [zhang66633/dsh-plugin-installer](https://github.com/zhang66633/dsh-plugin-installer) | 安装与排查 dsh 插件的技能（bundled skill provider）：npm 直装 / GitHub clone 注册，MCP·技能·皮肤路径，13 坑配方，patch-skins.sh 版本条件化补丁；已发布 npm@1.1.0 |
 
 ## 📡 远程渠道
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-installer |
| 仓库 | https://github.com/zhang66633/dsh-plugin-installer |
| 一句话说明 | 安装与排查 dsh 插件的技能（bundled skill provider）：npm 直装 / GitHub clone 注册，MCP·技能·皮肤路径，13 坑配方，版本条件化皮肤补丁 |
| 版本 | 1.1.0 |

## 自检清单

- [x] package.json `name` 使用自有命名空间（`dsh-plugin-installer`，未占用 `@deepseek-ai/*`；无 `@dsh-external/*` 权限故未用该 scope）
- [x] 仓库已打 `dsh-plugin` topic
- [x] PR 页面已勾选 **Allow edits from maintainers**（需在 PR 页面操作）
- [x] 所有运行时依赖已声明（`dependencies: yaml`；`peerDependencies: @deepseek-ai/cordis@^4.0.1, @deepseek-ai/dsh-skill@^0.1.0-rc.6`）
- [x] 自检实测：
  - **npm 已发布**：`dsh-plugin-installer@1.1.0`，tarball 干净 import，provider `list()`/`get()` 返回技能（5453 字符）
  - **加载级**：`dsh --profile web --dump-config` 组合树含 `dsh-plugin-installer`，无 plugin tree 错误
  - **apply 级**：mock-ctx 跑 `apply()` → `ctx.skills.registerProvider()` → list/get 正常
  - **CI**：GitHub Actions 绿（check + smoke + node:test 6 例 + shellcheck）
  - 说明：纯技能提供方插件（无服务端逻辑/无工具调用面），故未跑 `dsh --profile headless ... "hi"` 全量 boot（避免触碰运行中实例 + LLM 调用）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-plugin-installer | [zhang66633/dsh-plugin-installer](https://github.com/zhang66633/dsh-plugin-installer) | 安装与排查 dsh 插件的技能（bundled skill provider）：npm 直装 / GitHub clone 注册，MCP·技能·皮肤路径，13 坑配方，patch-skins.sh 版本条件化补丁；已发布 npm@1.1.0 |

## 备注

纯技能型插件（bundled skill provider，镜像 dsh-review-skills 模式），属 🎓 技能 类目。README 已按合格标准补齐 9 章节（Overview / Compatibility / Install·Uninstall / Quick start / Configuration / Permissions & data / Troubleshooting / Development / License & security），最后验证日期 2026-08-14。
