### PR TITLE
docs: 登记 dsh-mnemon

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -46,6 +46,7 @@
 | vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;可选设置页 UI(真实会话闭环实测:发现/连接/增删/别名预填) | ✅ |
 | dsh-latexcp | [Chi-hong22/dsh-latexcp](https://github.com/Chi-hong22/dsh-latexcp) | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式复制按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式 | 待测 |
 | dsh-plugin-web-access | [junhongchashui/dsh-plugin-web-access](https://github.com/junhongchashui/dsh-plugin-web-access) | 纯本地按需网页访问：web_fetch 命令行抓取 + 无头浏览器（browser_open/snapshot/eval/screenshot）双通道，零 API Key，注册 ctx.web fetch provider | ✅ |
+| dsh-mnemon | [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 深度集成的本地记忆系统：运行时热记忆 / 项目档案 / 长期记忆体三层存储，受监督写回、检索工具与 8 页 Web UI | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-mnemon |
| 仓库 | https://github.com/omdsh-dev/dsh-mnemon |
| 一句话说明 | Mnemon 深度集成的本地记忆系统：运行时热记忆 / 项目档案 / 长期记忆体三层存储，受监督写回、检索工具与 8 页 Web UI |
| 版本 | 0.1.0（已发布 npm，MIT） |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 为 `dsh-mnemon`，由 omdsh-dev org 发布（自有命名空间），未占用 `@deepseek-ai/*` / `@dsh-external/*` 保留命名空间
- [x] 仓库已打 `dsh-plugin` topic（并含 dsh / deepseek-harness 等 17 个 topic）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（创建后请在页面确认；fork 端已开启）
- [x] 所有运行时依赖已声明（`peerDependencies`: cordis / react / react-dom；`dependencies`: markdown-to-jsx / schemastery）
- [x] 已按自检三步实测通过：

```bash
# live web profile（dsh web，127.0.0.1:3080）已安装运行 dsh-mnemon@0.1.0
# 加载级无报错；108 项 vitest 测试全绿（typecheck + test + build 验证链）
```

- [x] 自检结果：加载成功，记忆系统 8 页 Web UI 正常挂载（状态 / 运行时 / 记忆体 / 档案 / 沉淀 / 检索 / 实体 / 内容）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-mnemon | [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 深度集成的本地记忆系统：运行时热记忆 / 项目档案 / 长期记忆体三层存储，受监督写回、检索工具与 8 页 Web UI |

## 备注

- 运行级标 ✅ 的依据：插件已在 live web profile 持续运行，另有 108 项自动化测试（确定性控制面：锁 / revision 冲突拒绝 / 字节级容量核算 / 原子写）。
- 说明与 README 双语（zh-CN / en）一致，安全与权限边界见仓库 docs/operations 文档。