### PR TITLE
docs: 登记 DSH-Plugins-Marketplace

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -52,6 +52,7 @@
 | dsh-turn-watchdog | [Equinox7379/dsh-turn-watchdog](https://github.com/Equinox7379/dsh-turn-watchdog) | 回合守夜人：检测疑似卡住的会话并注入警示（turn_watchdog_status 工具） | ✅ |
 | dsh-session-repair | [Equinox7379/dsh-session-repair](https://github.com/Equinox7379/dsh-session-repair) | 会话日志修复：给未知事件类型补 ignorable 并按合规帧格式重写，修复 SessionFormatUnsupportedError（修复前自动备份） | 待测 |
 | dsh-update-radar | [Equinox7379/dsh-update-radar](https://github.com/Equinox7379/dsh-update-radar) | 已装插件更新雷达：git 对比 link 插件本地与上游 HEAD，报告落后项（只读） | 待测 |
+| DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | DSH-Plugins-Marketplace |
| 仓库 | https://github.com/bradeGithub/DSH-Plugins-Marketplace |
| 一句话说明 | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别，静态索引 CI 每 2 小时刷新，中英双语 |
| 版本 | 1.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）——**说明**：包名为无 scope 的 `dsh-plugin-marketplace`，未占用保留命名空间（与已登记条目如 `dsh-tray` 一致，无 scope 亦被收录）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（通过 `gh pr create --allow-edits` 开启）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）——本插件无第三方运行时依赖，`dsh.client` 注入的平台模块（`@deepseek-ai/dsh-client-runtime` / `dsh-client-ui-settings`）由 DSH 宿主提供
- [x] 已按自检三步实测通过：

```bash
# 1/2/3. 实际运行验证
# 本插件即运行在当前 DSH 实例的 web profile（~/.dsh/profiles/web/node_modules/dsh-plugin-marketplace）：
# - 设置页「DSH插件市场」正常加载，列表/安装/更新/已安装识别均可用
# - lib/index.js 服务端模块可被 node 正常加载（ESM import 验证通过）
# - 已通过 33+ 项单元测试（检测逻辑、安全校验、依赖解析等）
```

- [x] 自检结果贴这里：加载成功——web profile 实测运行中，设置页市场面板正常，服务端模块 `node --check` 与 ESM 加载均通过

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |

## 备注

- 仓库名 `DSH-Plugins-Marketplace`（大写）与包名 `dsh-plugin-marketplace` 不同：表格按约定使用 repo 名；包名保持 npm 小写规范
- 功能：静态索引（jsDelivr/API 多源 + 搜索兜底）、安装管线自动识别 skill/agent 预设/cordis 插件/安装脚本、npm 生命周期脚本执行确认、安装失败自动清理、版本检测与更新
- 运行级 ✅：已在 DSH web profile 实测运行（即当前实例）