### PR TITLE
docs: 登记 dsh-plugin-audit

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -39,6 +39,7 @@
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ✅ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
 | dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一 DeepSeek Harness 进程里的不同 Agent 会话互相收发消息 | 待测 |
+| dsh-plugin-audit | [jkrandom-sudo/dsh-plugin-audit](https://github.com/jkrandom-sudo/dsh-plugin-audit) | 插件安全审计器：plugin_audit 静态权限画像（能力/凭证路径/外发主机，文件行号实证，只读契约）+ tools/pre-execute 运行时哨兵（凭证访问/非白名单外发/dotfile 写入 → 审批）；23 单测 + headless/web 真实 profile 双验证 | ✅ |
 | dsh-claude-move | [PerryLink/dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 从 Claude Code 全保真复制历史会话/记忆/技能/CLAUDE.md 到 DSH：可续聊会话按项目归入工作区，复制式增量同步（与运行中的 Claude Code 实时续写），Web 面板 + /claude-import-all + /resume-claude | 待测 |
 | dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |
 | dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-audit |
| 仓库 | https://github.com/jkrandom-sudo/dsh-plugin-audit |
| 一句话说明 | 插件安全审计器：plugin_audit 静态权限画像 + tools/pre-execute 运行时哨兵（凭证访问/非白名单外发/dotfile 写入 → 审批） |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）—— 说明：使用无 scope 的 `dsh-plugin-audit`（npm 已发布同名包），未占用 `@deepseek-ai/*` 保留命名空间；插件名与 repo 名一致
- [x] 仓库已打 `dsh-plugin` topic（另打 `deepseek-harness` / `dsh` / `security` / `audit`）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（用户 fork 默认开启）
- [x] 所有运行时依赖已声明（零运行时 dependencies；`cordis` / `schemastery` 声明为 peerDependencies）
- [x] 已按自检三步实测通过：

```bash
# 实际执行（等效且更贴近真实用法——bundle patch 自动插入行，无需 --patch）：
dsh plugin --profile headless add /path/to/dsh-plugin-audit   # 写入依赖 + dsh.profile.bundles
dsh --profile headless "Reply with exactly: audit-plugin-loaded"
# 输出：audit-plugin-loaded（零报错，模型往返正常）
```

- [x] 自检结果贴这里：**加载成功**。headless profile 零报错启动并完成模型往返；另在 web profile 做过更深的运行时验证：`ToolRuntime.get('plugin_audit')` 可解析、哨兵在真实 `tools/pre-execute` waterfall 上对 `cat ~/.ssh/id_rsa` 返回 `ask`、对 `pnpm test` 正常委托、`plugin_audit` 对可疑样本插件端到端审计返回 `risk=review` / 10 findings / `writesPerformed=false`。单测 23/23 全绿（vitest）。

## 改动内容

PLUGINS.md「🔌 单插件」表格追加一行：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-plugin-audit | [jkrandom-sudo/dsh-plugin-audit](https://github.com/jkrandom-sudo/dsh-plugin-audit) | 插件安全审计器：plugin_audit 静态权限画像（能力/凭证路径/外发主机，文件行号实证，只读契约）+ tools/pre-execute 运行时哨兵（凭证访问/非白名单外发/dotfile 写入 → 审批）；23 单测 + headless/web 真实 profile 双验证 |

## 备注

- 验证环境：DSH 主线 2026-08-14 快照（`npx @deepseek-ai/dsh`），Node v22.22.3，macOS；详细验证记录见仓库 README「Development / 端到端验证」与 v0.1.0 Release notes。
- 已发布 npm：`dsh-plugin-audit@0.1.0`（`dsh plugin --profile web add dsh-plugin-audit` 即可安装）。
- 已知边界： `./invariant` 伴随插件已导出但不随 bundle patch 接入——官方 web/base profile 不提供 `invariants` 服务，强行接入会阻断启动（README 兼容性节已说明）。
- 雷达重点跟踪维度建议：运行级 ✅（web + headless 双 profile 实测）；安全审计维度本身即本插件主题。
