### PR TITLE
docs: 登记 dsh-doublecheck

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -53,6 +53,7 @@
 | dsh-session-repair | [Equinox7379/dsh-session-repair](https://github.com/Equinox7379/dsh-session-repair) | 会话日志修复：给未知事件类型补 ignorable 并按合规帧格式重写，修复 SessionFormatUnsupportedError（修复前自动备份） | 待测 |
 | dsh-update-radar | [Equinox7379/dsh-update-radar](https://github.com/Equinox7379/dsh-update-radar) | 已装插件更新雷达：git 对比 link 插件本地与上游 HEAD，报告落后项（只读） | 待测 |
 | DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |
+| dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审；原生实现于 DSH 扩展点（技能/工具策略/审批 seam/会话日志） | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
<!--
  插件登记 PR 模板 —— 按此格式提交，合并后立即进入目录。
  目标文件：PLUGINS.md（表格追加一行即可）。
-->

> 📌 **标题格式**：`docs: 登记 <插件名>`（示例：`docs: 登记 dsh-balance`）——请勿使用其他标题格式。
>
> 🛠 **合并小贴士（重要）**：请让维护者能帮你 rebase——两种方式任选其一：
> 1. 提交 PR 后，在 PR 页面右侧勾选 **Allow edits from maintainers**；
> 2. 或在自己 fork 仓库的 Settings → General 勾选 **Allow edits and access to secrets by maintainers**（一次开启，以后所有 PR 自动允许）。
>
> 🙏 **致歉说明**：最近 README/PLUGINS.md 正在高速更改中（每日快照更新 + 分类体系重构），多个 PR 同时登记同一区域时可能产生冲突，处理可能稍显延迟，请见谅。

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-doublecheck |
| 仓库 | https://github.com/PerryLink/dsh-doublecheck |
| 一句话说明 | 交付前三查：查需求（grill-requirements 技能 + spec/catalog 工具）、查实现（red/green 证据门）、查证据（v0.3 对抗评审 + v0.4 六维校验） |
| 版本 | 0.5.0 |

## 自检清单（提交前逐项确认）

- [ ] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（或已在 fork Settings → General 开启同项，一次开启后续自动生效）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已按自检三步实测通过：

```bash
# 1. 安装最新 dsh 并加载你的插件
dsh --profile headless --patch <(printf -- '- insert:\n    - id: my-plugin\n      name: @dsh-external/my-plugin\n') "hi"
# 2. 无报错即通过加载级；有报错按提示修依赖声明
# 3. 声明所有运行时依赖（react 等）到 package.json dependencies
```

- [x] 自检结果贴这里：加载级通过（等价步骤真实执行，输出见下方「备注」，v0.5.0 tarball 复测）。

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 交付前三查：查需求（grill-requirements 技能 + spec/catalog 工具）、查实现（red/green 证据门）、查证据（v0.3 对抗评审）；bundle 双行 grill/guard 随服务自动激活，headless 加载实测通过 | 待测 |

## 备注

- **scope 说明**：README「给插件开发者 → 最低收录条件」写明「包名应使用你有权控制的命名空间。只有获得 `dsh-external` 维护权限的项目才应使用 `@dsh-external/*`」。本插件当前使用自有命名空间 `dsh-doublecheck`（未占用 `@deepseek-ai/*` 或任何他人命名空间），待获得 dsh-external 维护权限后再迁移 scope，故该清单项未勾选。
- **自检命令改写说明**：模板命令的 `<(printf …)` 是 bash 进程替换语法，Windows PowerShell 不支持；且包尚未发布 npm（`npm view dsh-doublecheck` → E404），裸 `name:` 行无法解析。按模板本意（安装并加载）等价执行，环境 Windows + dsh CLI 0.1.0-rc.6，真实输出如下（v0.5.0 tarball，2026-08-14 复测）：

```text
$ pnpm run build        # tsc --noEmitOnError，通过
$ pnpm pack             # → dsh-doublecheck-0.5.0.tgz
$ dsh plugin --profile dblcheck-verify add <tarball>   # 进入 bundles 列表
$ dsh --profile dblcheck-verify --dump-config
# == dsh-doublecheck
- id: doublecheck-grill
  name: dsh-doublecheck/grill
- id: doublecheck-guard
  name: dsh-doublecheck/guard

$ dsh --profile dblcheck-verify "hi"
Hi! I'm ready to help with your work in the DeepSeek Harness repo. What would you like to do?
（agent 正常回复，任务完成，无 FAILED/报错）
```

- 未验证项：模板命令的 `--patch <(printf …)` 原样形式未执行（bash 进程替换在 Windows 不可用 + 包未发布 npm），已按等价步骤（tarball 安装 → dump-config → headless 任务）真实执行并通过。
