### PR TITLE
docs: 登记 dsh-approval-guardian

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -109,5 +109,6 @@
 
 <!-- 新增条目示例（复制下面一行修改后插入对应分类表格末尾）：
 | my-plugin | [你的账号/my-plugin](https://github.com/你的账号/my-plugin) | 一句话功能描述 | 待测 |
+| dsh-approval-guardian | [karuboniru/dsh-approval-guardian](https://github.com/karuboniru/dsh-approval-guardian) | DSH æ²ç®±ææå®¡æ¹å®æ¤ï¼æçå®ç sandbox escalation å®¡æ¹è·¯ç±å°ä¸æ¬¡æ§æ å·¥å·è¯å®¡ agentï¼è¿åç»æå allow/denyï¼æ®éå·¥ä½åºæä½é¶ä»å¥ | å¾æµ |
 -->
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-approval-guardian |
| 仓库 | https://github.com/karuboniru/dsh-approval-guardian |
| 一句话说明 | DSH 沙箱提权审批守护：把真实的 sandbox escalation 审批路由到一次性无工具评审 agent，返回结构化 allow/deny，普通工作区操作零介入 |
| 版本 | 0.1.1 |

## 自检清单

- [x] package.json `name` 为 `dsh-approval-guardian`（作者自有命名空间，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 提供 `main`/`exports`/`dsh.bundle.patch` 集成入口；README 含 Overview/Compatibility/Install/Uninstall/Quick start/Configuration/Permissions/Development；MIT 许可证
- [x] 自检结果：自动审批机制已在真实会话中端到端运行验证（严格沙箱扩权 → 启动无工具 reviewer → 应用结构化 `allow`/`deny`），DSH CLI `0.1.0-rc.6`，2026-08-14；README 已同步记录该版本确认正常。雷达侧「运行级」标记保留为「待测」，交由雷达运行级实测流程自动判定。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-approval-guardian | [karuboniru/dsh-approval-guardian](https://github.com/karuboniru/dsh-approval-guardian) | DSH 沙箱提权审批守护：把真实的 sandbox escalation 审批路由到一次性无工具评审 agent，返回结构化 allow/deny，普通工作区操作零介入 |

## 备注

- 同时更新了 `scripts/gen-catalog.sh` 的 `EXTRA_REPOS`，使该插件在下一次 README 目录渲染时归入「🤖 Agent 能力」。
- `PLUGINS.md` 单插件表运行级保留「待测」，由雷达运行级实测流程自动填写。