### PR TITLE
docs: 登记 dsh-tianshu-tui

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -109,5 +109,6 @@
 
 <!-- 新增条目示例（复制下面一行修改后插入对应分类表格末尾）：
 | my-plugin | [你的账号/my-plugin](https://github.com/你的账号/my-plugin) | 一句话功能描述 | 待测 |
+| dsh-tianshu-tui | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | åºäºå®æ¹ DeepSeek Harness è£åªçäº¤äºå¼ç»ç«¯ UIï¼å®æ¶ä¼è¯ãå¾ç/è§è§æ¡¥ï¼å¹¶æ¥å¥æ¹é å·¥ä½æµãTDD è¯æ®é¨ä¸æºè½ç´¢å¼ | å¾æµ |
 -->
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-tianshu-tui |
| 仓库 | https://github.com/huiliyi37/dsh-tianshu-tui |
| 一句话说明 | 基于官方 DeepSeek Harness 裁剪的交互式终端 UI：实时会话、图片/视觉桥，并接入改造工作流、TDD 证据门与智能索引 |
| 版本 | 0.1.1-rc.6（npm `@huiliyi37/dsh-tianshu-tui`，`latest`） |

对应插件仓收录通知：[huiliyi37/dsh-tianshu-tui#2](https://github.com/huiliyi37/dsh-tianshu-tui/issues/2)。目录里已有自动扫描的短描述「DSH 的 TUI（终端界面）」，本 PR 只改这一行说明，不重复追加。

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用 `@deepseek-ai/*`（当前为 `@huiliyi37/dsh-tianshu-tui`；`@dsh-external/*` 以有权控制的命名空间为准，见备注）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`dependencies`：chalk / diff / get-east-asian-width / string-width；`peerDependencies`：`@deepseek-ai/cordis` 与官方 `@deepseek-ai/dsh-*` `^0.1.0-rc.6`）
- [x] 已按自检三步实测通过（官方 CLI `0.1.0-rc.6`，隔离 `DSH_HOME`）

安装与启动：

```sh
npx -y @deepseek-ai/dsh plugin --profile tui add @huiliyi37/dsh-tianshu-tui
npx -y @deepseek-ai/dsh --profile tui
```

自检结果：2026-08-13 在隔离 `DSH_HOME=/tmp/dsh-tianshu-envtest` 按上面两条命令安装并启动，欢迎页出现 `dsh-tianshu-tui`，`deepseek-v4-flash · API ✓`，无 `dsh-root` 加载错误。记录见插件仓 [docs/BASELINE-v0.1.0-rc.6.md](https://github.com/huiliyi37/dsh-tianshu-tui/blob/main/docs/BASELINE-v0.1.0-rc.6.md)。当前 npm `latest` 为 `0.1.1-rc.6`。

## 改动内容

PLUGINS.md「🔌 单插件」表格中更新已有行（不追加重复条目）：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-tianshu-tui | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 基于官方 DeepSeek Harness 裁剪的交互式终端 UI：实时会话、图片/视觉桥，并接入改造工作流、TDD 证据门与智能索引 | 待测 |

## 备注

- 本插件是官方 DeepSeek Harness 上的展示层：在官方基础之上做成 TUI 终端界面，支持剪贴板/终端图形协议图片与视觉桥；工作流、TDD 证据门、语义/代码智能索引由宿主 harness 提供，TUI 作为主要交互面。
- 包名用自有 scope `@huiliyi37/dsh-tianshu-tui`，不占用 `@deepseek-ai/*`。获得 `dsh-external` 维护权限后再考虑迁移。
- 运行级保持 `待测`，等本仓库雷达实测；加载级自检见上，未虚构结果。
- 插件 id 固定为 `tui-runner`。