### PR TITLE
Add dsh-spend to plugin registry

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -10,6 +10,7 @@
 
 | 插件 | 仓库 | 说明 | 运行级 |
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
+| dsh-spend | [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | Token 用量统计与预计费用：右下角悬浮窗，按模型/按天/按会话多维聚合，内置供应商知识库自动识别计费计划（web bundle） | ✅ |
 | dsh-tray | [qing3a/dsh-tray](https://github.com/qing3a/dsh-tray) | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 | ✅ |
 |---|---|---|---|
 | dsh-bash-terminal | [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) | Windows 三终端 shell 工具（PowerShell/Git Bash/WSL，默认终端由用户在设置中选择）+ 交互式 PTY 终端 + 官方沙箱对接；4 套件测试 + GitHub Actions CI 全绿 | ✅ |


### PR DESCRIPTION
Manual registration of [dsh-spend](https://github.com/nonewind/dsh-spend) (repo also carries the `dsh-plugin` topic, so the daily scan would pick it up anyway).

- Token usage & estimated spend stats for the DSH web UI: floating panel, per-model / per-day / per-session aggregation, auto-detected billing plans (17 providers / 131 models in the built-in knowledge base).
- Declares a `dsh.bundle` manifest; install via `dsh plugin --profile web add dsh-spend`.