### PR TITLE
andbase-harness and sandbase-skills

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -112,5 +112,5 @@
 <!-- 新增条目示例（复制下面一行修改后插入对应分类表格末尾）：
 | my-plugin | [你的账号/my-plugin](https://github.com/你的账号/my-plugin) | 一句话功能描述 | 待测 |
 | dsh-tianshu-tui | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | åºäºå®æ¹ DeepSeek Harness è£åªçäº¤äºå¼ç»ç«¯ UIï¼å®æ¶ä¼è¯ãå¾ç/è§è§æ¡¥ï¼å¹¶æ¥å¥æ¹é å·¥ä½æµãTDD è¯æ®é¨ä¸æºè½ç´¢å¼ | å¾æµ |
--->
-
+| sandbase-harness | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | DSH bundle for SandBase managed-agents, exposing agent discovery, durable sessions, streamed runs, artifacts, and cancellation over stdio MCP; verified against DSH `47f9438` | â |-->
+| sandbase-skills | [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) | Research and growth skill collection with an npm CLI that installs complete bundles into DSH's native `.dsh/skills` discovery root; verified against DSH `47f9438` |


### PR DESCRIPTION
## Summary

Register two SandBase projects with English catalog descriptions:

- `sandbase-harness`: a DSH bundle exposing managed-agent discovery, durable sessions, streamed runs, artifacts, and cancellation over stdio MCP.
- `sandbase-skills`: a research and growth skill collection with an npm CLI that installs complete bundles into DSH's native `.dsh/skills` discovery root.

## Validation

- Both repositories are public and tagged with `dsh-plugin`.
- Default-branch manifests, entry points, licenses, install/uninstall instructions, permissions, troubleshooting, and security guidance were checked.
- Both integrations were verified against DSH commit `47f943859bef60e4160492346772ded9b24f765a`.
- Source CI and package/skill validation passed.
- `python3 scripts/validate-catalog.py` passed: 44 catalog entries, IDs and names unique, counts conserved.
- Package names remain outside the reserved `@deepseek-ai/*` namespace.