### PR TITLE
docs: 登记 dsh-plugin-automations

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -18,6 +18,7 @@
 | dsh-split-panes | [dsh-external/dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) | 分屏面板 | ✅ |
 | dsh-question-collapse | [dsh-external/dsh-question-collapse](https://github.com/dsh-external/dsh-question-collapse) | 问题折叠 | ✅ |
 | dsh-sentinel | [fuhefei/dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) | 事件驱动唤醒 agent loop（文件/命令/http/进程/webhook 传感器） | 待测 |
+| dsh-plugin-automations | [Sev7een/dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) | Web 设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态 | 待测 |
 | dsh-tianshu-tui | [huiliyi37/dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 的 TUI（终端界面） | 待测 |
 | dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI 内联交互组件：dsh-ui fence 渲染图表/表单/测验/3D 场景，带 action 事件环 | 待测 |
 | dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-automations |
| 仓库 | https://github.com/Sev7een/dsh-plugin-automations |
| 一句话说明 | Web 设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态 |
| 版本 | 0.2.0 |

## 自检清单（提交前逐项确认）

- [x] `package.json` 名称为 `dsh-plugin-automations`，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已添加 `dsh-plugin` topic
- [x] 已允许维护者编辑 PR 分支
- [x] 所有运行时依赖已在 `dependencies` / `peerDependencies` 声明
- [x] 已完成类型检查、客户端语法检查、测试、构建和打包预检

```bash
npm run check
npm test
npm run build
npm pack --dry-run
```

- [x] 自检结果：全部通过；8 个测试文件、50 项测试通过，其中包含组合配置 e2e 测试；打包预检包含 Host、Client bundle 和 `cordis.patch.yml`

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-plugin-automations | [Sev7een/dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) | Web 设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态 | 待测 |

## 备注

- 支持准点执行和 DeepSeek 谷时段执行。
- 支持单次任务和按本地墙钟时间每日重复。
- 每次运行创建隔离 Session，任务状态通过 `ctx.storageDomain` 持久化。
- 许可证：MIT。
