### PR TITLE
docs: 登记 dsh-repo-context

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -9,6 +9,7 @@
 ## 🔌 单插件
 
 | 插件 | 仓库 | 说明 | 运行级 |
+| dsh-repo-context | [qing3a/dsh-repo-context](https://github.com/qing3a/dsh-repo-context) | 把 git 状态与仓库规范动态注入 system prompt（section/context/variable，官方 system-prompt 缝隙插件）；dsh-plugin-verify 0.1.2 实测 7/7 waterfall + 工具真实执行（R3 isError:false） | ✅ |
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
 | dsh-tray | [qing3a/dsh-tray](https://github.com/qing3a/dsh-tray) | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 | ✅ |
 |---|---|---|---|


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-repo-context |
| 仓库 | https://github.com/qing3a/dsh-repo-context |
| 一句话说明 | 把 git 状态与仓库规范动态注入 system prompt（section/context/variable，官方 system-prompt 缝隙插件）；dsh-plugin-verify 0.1.2 实测 7/7 waterfall + 工具真实执行（R3 isError:false） |
| 版本 | 0.1.0 |

## 自检清单

- [x] package.json name 使用 @qing3a scope（合法小写，未占用 @deepseek-ai/* 保留命名空间）
- [x] 仓库已打 dsh-plugin / dsh / deepseek-harness / system-prompt / git topic
- [x] 所有运行时依赖已声明（@deepseek-ai/schemastery deps + @deepseek-ai/dsh-system-prompt peerDeps）
- [x] README 含概述/安装卸载/Quick start/配置/权限数据/兼容性/验证/开发/License
- [x] 运行时验证实测（dsh-plugin-verify 0.1.2，mock 平台感知修正后）：**7/7 waterfall 链完整 + tools/result 工具真实执行成功（isError:false，非空转）；R1/R2/R3 全过**。报告：https://github.com/qing3a/dsh-plugin-verify/blob/main/reports/repo-context-2026-08-14.json ；判定站已收录：https://github.com/qing3a/dsh-plugin-verify

## 改动内容
- PLUGINS.md 单插件表新增一行（运行级 ✅，基于完整运行时验证）
