### PR TITLE
docs: 登记 dsh-session-cleaner-cli

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -85,6 +85,7 @@
 | deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 | 待测 |
 | dsh-remote-sandbox | [weijiafu14/dsh-remote-sandbox](https://github.com/weijiafu14/dsh-remote-sandbox) | 生产级远程执行世界：E2B 沙箱内纯 JS sidecar，fs/subprocess 单次往返、进程输出有界、心跳保活、崩溃透明恢复（resume/recreate）、tar 工作区同步；修复官方 e2b POC 两处 host 假设。43 项测试（含 6 项真机 E2E）全绿 | 已测 |
 | deepseek-harness-desktop | [cnskycn/deepseek-harness-desktop](https://github.com/cnskycn/deepseek-harness-desktop) | DeepSeek Harness (dsh) 官方 Web UI 的 Windows 桌面封装：一键安装包、内置完整 dsh 依赖、Node.js 自动检测与引导安装、原生窗口托管 | 待测 |
+| dsh-session-cleaner-cli | [ChenChen913/dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) | DSH 会话数据离线清理 CLI：按工作区交互/命令删除会话（回收站+恢复+自动备份）、同步工作区账目与投影缓存、修剪幽灵条目；零依赖 Node≥18，8 项端到端测试全绿 + CI | 待测 |
 
 ## ❓ 未分类
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-session-cleaner-cli |
| 仓库 | https://github.com/ChenChen913/dsh-session-cleaner-cli |
| 一句话说明 | DSH 会话数据离线清理 CLI：按工作区删除会话（回收站+恢复+备份），同步工作区账目与投影缓存，修剪幽灵条目 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用个人命名空间 `dsh-session-cleaner-cli`（未占用 `@deepseek-ai/*` 保留命名空间，也未占用 `@dsh-external/*`）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已开启 Allow edits from maintainers（fork 默认开启）
- [x] 所有运行时依赖已声明：零运行时依赖，无 `dependencies` / `peerDependencies`
- [x] 自检实测说明：本工具是**离线 CLI 配套工具**，不是可加载的 cordis 插件，模板中的 `dsh --profile headless` 加载级测试不适用；以 13 项端到端测试替代——在仿真 DSH_HOME 上驱动真实 CLI 子进程，覆盖 list / delete（回收站+账目+投影缓存同步）/ restore（归档状态还原）/ --purge / prune-ghosts / 交互式管道流 / 运行中服务拒绝 / 未知 id / 并发锁 / --pid-file / 非法 DSH_HOME 拒绝 / 不完整批次保护。Windows 11 + Node 24 实测 13/13 通过；GitHub Actions CI 覆盖 ubuntu / macos / windows × Node 18/20/24。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-session-cleaner-cli | [ChenChen913/dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) | DSH 会话数据离线清理 CLI：按工作区交互/命令删除会话（回收站+恢复+自动备份）、同步工作区账目与投影缓存、修剪幽灵条目；零依赖 Node≥18，13 项端到端测试 + 三平台 CI |

## 备注

- 分类放在 🛠 基础设施（配套工具，非 cordis 插件）。
- 与已登记的 fountunt/dsh-session-cleaner（运行中 Web 运行时 GUI 删除插件）互补：前者在 GUI 内单条删除，本工具离线批量整理、可恢复、可清理幽灵账目。
- 验证基线：deepseek-harness mainline `47f943859bef60e4160492346772ded9b24f765a`（2026-08-13），存储格式 workspace.json unit v2 / session_projcache.json unit v3。
- README 中英双版本（默认中文）；已打 `dsh-plugin` topic，雷达自动发现会在 8h 扫描内收录。
