### PR TITLE
docs: 登记 dsh-visual-plugin

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -52,6 +52,7 @@
 | dsh-turn-watchdog | [Equinox7379/dsh-turn-watchdog](https://github.com/Equinox7379/dsh-turn-watchdog) | 回合守夜人：检测疑似卡住的会话并注入警示（turn_watchdog_status 工具） | ✅ |
 | dsh-session-repair | [Equinox7379/dsh-session-repair](https://github.com/Equinox7379/dsh-session-repair) | 会话日志修复：给未知事件类型补 ignorable 并按合规帧格式重写，修复 SessionFormatUnsupportedError（修复前自动备份） | 待测 |
 | dsh-update-radar | [Equinox7379/dsh-update-radar](https://github.com/Equinox7379/dsh-update-radar) | 已装插件更新雷达：git 对比 link 插件本地与上游 HEAD，报告落后项（只读） | 待测 |
+| dsh-visual-plugin | [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) | DSH 视觉桥接插件：主模型无视觉时把用户图片转发到任意 OpenAI 兼容视觉模型（DeepSeek (Vision) 包装适配器 + Web 右侧面板配置/测试/历史），自动拦截描述并支持按问题定向提示词 | ✅ |
 | DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |
 
 ## 🧰 插件集


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-visual-plugin |
| 仓库 | https://github.com/jyh20030112/dsh-visual-plugin |
| 一句话说明 | DSH 视觉桥接插件：主模型无视觉时把用户图片转发到任意 OpenAI 兼容视觉模型（DeepSeek (Vision) 包装适配器 + Web 右侧面板配置/测试/历史），自动拦截描述并支持按问题定向提示词 |
| 版本 | 0.1.0 |

## 自检清单

- [x] package.json `name` 使用自有命名空间（`dsh-visual-plugin`，未占用 `@deepseek-ai/*` 保留命名空间；已发布到 npm）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已允许维护者编辑（通过 API 设置 `maintainer_can_modify: true`）
- [x] 所有运行时依赖已声明（`peerDependencies`：cordis / dsh-tools / dsh-settings / dsh-credentials / dsh-attachment / dsh-host-webserver / dsh-llm / dsh-system-prompt / dsh-invariants / dsh-agent / schemastery；`dependencies` 为空，零运行时依赖由 harness 安装提供；浏览器包仅 require 平台种子模块）
- [x] 自检实测：
  - 构建：tsc 类型检查 + tsdown 双端构建（host `lib/index.js` + browser closure-factory `lib/client.js`）通过
  - 运行级：`dsh plugin --profile web add` 安装 → `--dump-config` 组合树出现 `vision-bridge` 行 → Web UI 右侧面板（`shell.overlay`）正常显示，配置保存 / 测试连接 / 发图自动拦截描述（`agent/pre-step`）全链路跑通，面板 2s 轮询展示缩略图 + 描述；`DeepSeek (Vision)` 包装适配器让网关放行图片上传
  - 发布：tag `v0.1.0` 已通过 GitHub Actions 自动创建 GitHub Release 并 `npm publish`（`dsh-visual-plugin@0.1.0`）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-visual-plugin | [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) | DSH 视觉桥接插件：主模型无视觉时把用户图片转发到任意 OpenAI 兼容视觉模型（DeepSeek (Vision) 包装适配器 + Web 右侧面板配置/测试/历史），自动拦截描述并支持按问题定向提示词 |

## 备注

- 类目：🔌 单插件（Host + Client 双端 bundle）
- 已知限制：settings Web 网关只暴露仓库内白名单命名空间（`WEB_SETTINGS_NAMESPACES`），第三方插件无法经 settings RPC 暴露配置——本插件通过自有 `GET/POST /vision-bridge/config` 路由读写配置（同源 HTTP，api key 走 credentials 缝只写不回显）
- 对话模型需在模型选择器切到 `DeepSeek (Vision)`（包装适配器路由）才能放行图片上传