### PR TITLE
docs: 登记 dsh-failure-capsule

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -65,6 +65,7 @@
 | dsh-plugin-workshop | [yyyyukari/dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) | 创意工坊式插件浏览器：侧栏常驻入口，搜索/最热/最新/近 7-90 天飙升榜、中文关键词映射、描述与 README 机翻、插件特征验证过滤、一键安装/更新/卸载，内置已安装插件管理（零服务器，GitHub 直连） | ✅ |
 
 | dsh-mcp-adapter | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | 一个 mcp 代理工具：按需 search/describe/call，不把每个 MCP schema 塞进上下文；Web `/mcp` 菜单可添加/连接/授权 | ✅ |
+| dsh-failure-capsule | [YiHarvest/dsh-failure-capsule](https://github.com/YiHarvest/dsh-failure-capsule) | 本地优先故障证据包：工具或 Agent 失败时自动导出脱敏 ZIP，汇总有界会话时间线、Git 状态、运行环境与插件清单；不联网、不调用模型 | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-failure-capsule |
| 仓库 | https://github.com/YiHarvest/dsh-failure-capsule |
| 一句话说明 | 本地优先故障证据包：工具或 Agent 失败时自动导出脱敏 ZIP，汇总有界会话时间线、Git 状态、运行环境与插件清单；不联网、不调用模型 |
| 版本 | 0.1.0 |

## 自检清单

- [x] `package.json` 使用本人控制的公开 npm 包名 `dsh-failure-capsule`，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已添加 `dsh-plugin` topic
- [x] 已允许维护者编辑此 PR
- [x] 所有运行时依赖已在 `dependencies` / `peerDependencies` 声明
- [x] Node.js v26.7.0 下 typecheck、13 项 Vitest、构建、publint 与 npm audit 均通过
- [x] 使用真实 Cordis + Loader + SessionStore 完成失败事件到 ZIP 的集成验证
- [x] 从 npm 公网全新安装 `dsh-failure-capsule@0.1.0` 后可正常导入，Profile Bundle 配置可解析
- [x] GitHub Actions CI 已通过：https://github.com/YiHarvest/dsh-failure-capsule/actions/runs/31784452584

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-failure-capsule | [YiHarvest/dsh-failure-capsule](https://github.com/YiHarvest/dsh-failure-capsule) | 本地优先故障证据包：工具或 Agent 失败时自动导出脱敏 ZIP，汇总有界会话时间线、Git 状态、运行环境与插件清单；不联网、不调用模型 |

## 备注

npm：https://www.npmjs.com/package/dsh-failure-capsule