### PR TITLE
docs: 登记 dsh-ci-doctor（CI 失败自动诊断）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -65,6 +65,7 @@
 | dsh-plugin-workshop | [yyyyukari/dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) | 创意工坊式插件浏览器：侧栏常驻入口，搜索/最热/最新/近 7-90 天飙升榜、中文关键词映射、描述与 README 机翻、插件特征验证过滤、一键安装/更新/卸载，内置已安装插件管理（零服务器，GitHub 直连） | ✅ |
 
 | dsh-mcp-adapter | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | 一个 mcp 代理工具：按需 search/describe/call，不把每个 MCP schema 塞进上下文；Web `/mcp` 菜单可添加/连接/授权 | ✅ |
+| dsh-ci-doctor | [jkrandom-sudo/dsh-ci-doctor](https://github.com/jkrandom-sudo/dsh-ci-doctor) | CI 失败自动诊断：ci_watch 后台监视新增失败运行（基线对比/退避/可取消）+ ci_diagnose 日志签名提取分类（嫌疑文件/裁剪摘录/markdown 诊断卡）+ 失败签名账本去重复发；85 单测 + web profile 进程内 boot 18 项 + headless 真实模型回路实测 | ✅ |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-ci-doctor |
| 仓库 | https://github.com/jkrandom-sudo/dsh-ci-doctor |
| 一句话说明 | CI 失败自动诊断修复闭环：ci_watch 后台监视新增失败运行 + ci_diagnose 日志签名提取分类 + 失败签名账本去重复发 |
| 版本 | v0.1.0（npm: `dsh-ci-doctor`） |

## 自检清单

- [x] `dsh plugin --profile headless add <repo>` 安装成功（link 安装进 headless profile）
- [x] `dsh --profile headless "..."` 真实模型回路通过：模型实际调用 `ci_diagnose` 诊断 cli/cli，并正确答出两个 `ci_*` 工具（ci_diagnose / ci_watch）
- [x] 单元测试 85/85 全绿（签名提取/日志裁剪/gh 客户端/监视状态机/账本/插件装配/invariant 伴随件）
- [x] web 真实 profile 进程内 `boot()` 验证 18/18：工具注册进真实 tools 运行时、pre/post-execute 瀑布接受真实宿主执行形态 `{ name, arguments }`、对 cli/cli run [#31782742089](https://github.com/cli/cli/actions/runs/31782742089) 实时诊断提取 8 条签名、真实 watch job 流出基线并响应 kill、签名账本持久化到 `~/.dsh/storages/ci_doctor.json`（跨进程重启存活）

## 改动内容

- `PLUGINS.md`「🔌 单插件」表追加一行 dsh-ci-doctor（运行级 ✅）

## 备注

- 只读契约：两个工具只读 GitHub 状态（`gh api` + `--jq` 投影），绝不 push/合并/取消/重跑；结果携带 `repositoryWrites: false` 标记，附带可选 invariant 伴随件在丢失标记时立即报错。
- 实测中修复过两个真实环境才暴露的问题（挂载时序竞争下 shell/storageDomain 的懒获取、宿主 shell 64 KiB 捕获上限导致 gh JSON 截断），单测无法覆盖、实机验证抓到。
