### PR TITLE
docs: 登记 dsh-suite（插件活目录 + 脚手架 + 内置商店）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -86,6 +86,7 @@
 | deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 | 待测 |
 | dsh-remote-sandbox | [weijiafu14/dsh-remote-sandbox](https://github.com/weijiafu14/dsh-remote-sandbox) | 生产级远程执行世界：E2B 沙箱内纯 JS sidecar，fs/subprocess 单次往返、进程输出有界、心跳保活、崩溃透明恢复（resume/recreate）、tar 工作区同步；修复官方 e2b POC 两处 host 假设。43 项测试（含 6 项真机 E2E）全绿 | 已测 |
 | dsh-session-cleaner-cli | [ChenChen913/dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) | DSH 会话数据离线清理 CLI：按工作区交互/命令删除会话（回收站+恢复+自动备份）、同步工作区账目与投影缓存、修剪幽灵条目；零依赖 Node≥18，8 项端到端测试全绿 + CI | 待测 |
+| dsh-suite | [whyihaveyou/dsh-suite](https://github.com/whyihaveyou/dsh-suite) | DSH 插件活目录 + 脚手架 + 内置插件商店：785+ 插件每小时刷新、每日兼容 CI 实测、中英双语可搜索目录站；含 create-dsh-plugin 脚手架与 plugin-manager / plugin-notify / plugin-session-export / plugin-team-board 五个 npm 包 | 已测 |
 
 ## ❓ 未分类
 


### PR DESCRIPTION
登记 dsh-suite（https://github.com/whyihaveyou/dsh-suite）到「🛠 基础设施」分类。

说明：
- 这不是单个插件，而是一套目录 + 脚手架 + 内置商店（基础设施类），所以按「🛠 基础设施」登记。
- 目录覆盖 785+ 插件、每小时刷新、每日兼容 CI 实测；五个 npm 包（create-dsh-plugin 脚手架 + plugin-manager / plugin-notify / plugin-session-export / plugin-team-board）均已发布并做过 `dsh plugin add` 装载验证。
- 命名空间：我们的包用自己控制的 `@dsh-suite/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）；repo 已打 `dsh-plugin` topic。
- 已勾选 Allow edits from maintainers。

谢谢维护！