### PR TITLE
docs: 登记 dsh-vision-router

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -103,3 +103,4 @@
 | dsh-auto-continue | [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | DSH Web 请求中断自动续跑插件：回合因网络/超时等非人为原因失败后自动发送「继续」续跑（含宿主崩溃遗留回合扫描恢复），全部参数可在设置→插件配置中调整 | ✅ |
 | sandbase-harness | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | DSH bundle for SandBase managed-agents, exposing agent discovery, durable sessions, streamed runs, artifacts, and cancellation over stdio MCP; verified against DSH 47f9438 | ✅ |
 | sandbase-skills | [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) | Research and growth skill collection with an npm CLI that installs complete bundles into DSH native .dsh/skills discovery root; verified against DSH 47f9438 | 待测 |
+| dsh-vision-router | [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用，无 Python，一条命令安装 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-vision-router |
| 仓库 | https://github.com/ysr666/dsh-vision-router |
| 一句话说明 | 为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用，无 Python，一条命令安装 |
| 版本 | 0.2.0 |

## 自检清单

- [x] package.json 未占用 @deepseek-ai/* 保留命名空间（名称为 dsh-vision-router）
- [x] 仓库已打 dsh-plugin topic
- [x] 已勾选 Allow edits from maintainers
- [x] 运行时依赖已声明（dependencies: undici/sharp/potrace 等，peerDependencies 已列 @deepseek-ai 生态包）
- [x] 加载级自测：真实 Web profile 运行中——stealth 接管 deepseek-official、vision-http 路由、9 个视觉工具与设置卡片均正常；60 项单测 + CI 全绿

## 改动内容

| dsh-vision-router | [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 为纯文本 Agent 提供视觉能力：内置免 Key 视觉链 + 像素级视觉工具；粘贴图片即可用，无 Python，一条命令安装 | 待测 |