### PR TITLE
docs: dsh-ci-doctor 行更新到 v0.1.2 实测数据

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -60,7 +60,7 @@
 | dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审；原生实现于 DSH 扩展点（技能/工具策略/审批 seam/会话日志） | 待测 |
 
 | dsh-mcp-adapter | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | 一个 mcp 代理工具：按需 search/describe/call，不把每个 MCP schema 塞进上下文；Web `/mcp` 菜单可添加/连接/授权 | ✅ |
-| dsh-ci-doctor | [jkrandom-sudo/dsh-ci-doctor](https://github.com/jkrandom-sudo/dsh-ci-doctor) | CI 失败自动诊断：ci_watch 后台监视新增失败运行（基线对比/退避/可取消）+ ci_diagnose 日志签名提取分类（嫌疑文件/裁剪摘录/markdown 诊断卡）+ 失败签名账本去重复发；85 单测 + web profile 进程内 boot 18 项 + headless 真实模型回路实测 | ✅ |
+| dsh-ci-doctor | [jkrandom-sudo/dsh-ci-doctor](https://github.com/jkrandom-sudo/dsh-ci-doctor) | CI 失败自动诊断：ci_watch 后台监视新增失败运行（基线对比/退避/可取消）+ ci_diagnose 日志签名提取分类（嫌疑文件/裁剪摘录/markdown 诊断卡）+ 失败签名账本去重复发；102 单测 + web profile 进程内 boot 19 项 + headless 真实模型回路实测（v0.1.2 审查修复版） | ✅ |
 
 | dsh-hdc-bridge | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 鸿蒙设备桥：hdc 设备闭环（截图/装包/日志/崩溃/UI 自动化）+ 官方优先 API 知识层（SDK .d.ts + 离线 Tier-1 随包）+ DevEco CLI 构建/签名/lint；无头 DSH 实例真实 E2E 已验证 | ✅ |
 ## 🧰 插件集


### PR DESCRIPTION
## 改动内容

PLUGINS.md「🔌 单插件」表 dsh-ci-doctor 行的实测数据更新（PR #78 合并后推送的更新未进入合并范围，此为后续小 PR）：

- 85 单测 → **102 单测**
- web profile 进程内 boot 18 项 → **19 项**（新增账本 mtime 防空洞检查）
- 标注 v0.1.2 审查修复版

## 背景

dsh-ci-doctor 发布 v0.1.2：三方代码审查（核心逻辑/宿主集成安全/测试质量，20 项发现）修复版。主要修复：watcher 基线轮询失败误报历史失败（P1）、shell 适配层单测补实、账本并发串行化、日志摘录围栏 prompt-injection 加固等。

Release: https://github.com/jkrandom-sudo/dsh-ci-doctor/releases/tag/v0.1.2

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>