### PR TITLE
docs: 登记 dsh-wechat-bridge（DSH ⇄ 微信桥接 · 官方 iLink API · 零运行时依赖）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -79,6 +79,7 @@
 | dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps |
 | dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | ✅ |
 | dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | ✅ |
+| dsh-wechat-bridge | [gtaifu/dsh-wechat-bridge](https://github.com/gtaifu/dsh-wechat-bridge) | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw |
 
 ## 🛠 基础设施
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-wechat-bridge |
| 仓库 | https://github.com/gtaifu/dsh-wechat-bridge |
| 一句话说明 | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw |
| 版本 | 1.1.0 |

## 自检清单（提交前逐项确认）

- [x] 仓库已打 `dsh-plugin` topic（另有 deepseek-harness / dsh / wechat / wechat-bot / weixin / ilink）
- [x] 包名使用**自有命名空间** `dsh-wechat-bridge`（无 scope，npm 实测可用；符合公开目录「包名应使用你有权控制的命名空间，只有获得 dsh-external 维护权限的项目才应使用 @dsh-external/*」规则，未占用任何第三方 org 或保留命名空间）
- [x] package.json：非空 `name`、`main`（`lib/core.mjs` 程序化入口）、`bin`（`dsh-weixin`）、`files` 白名单（发布包不含测试/笔记/data）；零运行时依赖，无 `dependencies` 字段
- [x] README 已按公开目录要求重构为 9 章节：**Overview**（解决什么问题/适合谁）、**Compatibility**（DSH 版本声明 `dsh@0.1.0-rc.6`，最后验证 2026-08-14）、**Install / Uninstall**（安装/升级/禁用/彻底移除）、**Quick start**（最小示例 + mock iLink 可复现闭环）、**Configuration**（默认值/环境变量/敏感项 🔒 标记）、**Permissions & data**（文件/网络/凭据/用户数据/执行权限）、**Troubleshooting**（常见错误/日志位置/回滚）、**Development**（构建/测试/贡献/程序化入口）、**License & security**（MIT + SECURITY.md 私有漏洞报告）
- [x] LICENSE 为 MIT（GitHub API 已识别）；新增 SECURITY.md（私有漏洞报告流程）；.gitignore 覆盖 `data/`、`weixin-auth.json`、研究笔记
- [x] 插件自带测试通过（`node test-ws.mjs` 帧编解码 6/6 ✅；mock iLink 闭环含多会话 /new→/switch→/sessions→/clear 全链路 10 项断言 ✅）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（创建 PR 时通过 API 设置 `maintainer_can_modify=true`，等效勾选）
- [x] 自检三步实测：① npm 已发布 `dsh-wechat-bridge@1.1.0`（2026-08-14T12:45:56Z）；② ③ 已按 npm 包名实测通过（安装 → bin 冒烟 → 真实 DSH 任务，全部 exit 0）

> 说明：本插件是 CLI/桥接工具（`bin: dsh-weixin` + `main: lib/core.mjs` 驱动 `dsh --profile headless`），
> 集成入口不是 cordis insert 行——实测 DSH loader 对 insert 行只做裸 import、不会按包名自动安装
> （原 insert 写法直接 `ERR_MODULE_NOT_FOUND`）。因此加载实测按消费者真实路径验证：

```powershell
npm install -g --prefix <干净目录> dsh-wechat-bridge                          # → added 1 package in 776ms（registry 真实包）
<干净目录>\dsh-weixin.cmd --help                                              # bin 冒烟：--prefix 时 shim 落在 <prefix> 下，用全路径；普通 npm install -g 则裸名直接可用
node <干净目录>\node_modules\dsh-wechat-bridge\bridge.mjs test                # 真实 dsh --profile headless 任务 → 回复「收到」，exit 0
```

- [x] ③ 自检结果（2026-08-14，DSH `dsh@0.1.0-rc.6` / Node 22.23.2 / Windows）：
  - 发布：`dsh-wechat-bridge@1.1.0` 已发布至 npm（2026-08-14T12:45:56Z），tarball `https://registry.npmjs.org/dsh-wechat-bridge/-/dsh-wechat-bridge-1.1.0.tgz`
  - 安装：`npm install -g --prefix <干净目录> dsh-wechat-bridge` → `added 1 package in 776ms`；发布内容 = `files` 白名单 6 项（lib/、bridge.mjs、weixin-bot.mjs、dsh-weixin.cmd、LICENSE、README.md）+ npm 自动附带的 package.json，无 test/、data/、研究笔记
  - bin：`<干净目录>\dsh-weixin.cmd --help` 正常输出、exit 0（`--prefix` 装到自定义目录时 shim 不在 PATH，需全路径调用；普通 `npm install -g` 时裸名 `dsh-weixin` 直接进 PATH）
  - 真实 DSH 任务：`node <干净目录>\node_modules\dsh-wechat-bridge\bridge.mjs test` → 回复「收到」，exit 0 ✅

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-wechat-bridge | https://github.com/gtaifu/dsh-wechat-bridge | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw |

## 备注

- 直接走腾讯官方 iLink 机器人 API，无需 OpenClaw 全家桶 / 外部 daemon / ACP 栈，即插即用。
- Gitee 为国内镜像，GitHub 为对外主仓（package.json 的 `repository`/`homepage`/`bugs` 已指向 GitHub）。
- 包名最初尝试 `@dsh-external/*`，因该 org 非本人可控（公开目录规则明确禁止），已改回自有命名空间 `dsh-wechat-bridge`。
