### PR TITLE
docs: 更新 vpshub 描述与版本信息 (0.1.8)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -44,7 +44,7 @@
 | dsh-session-pins | [alooshxl/dsh-session-pins](https://github.com/alooshxl/dsh-session-pins) | 在侧边栏持久置顶并快速打开可用普通会话；rc.6 归档项可识别、可移除但不可重新打开（无凭据运行级实测） | ✅ |
 | dsh-cost-ledger | [suimi8/dsh-cost-ledger](https://github.com/suimi8/dsh-cost-ledger) | 跨会话持久成本账本：订阅 llm/stream 自动记录每次模型调用的 token 用量到 SQLite，内置 DeepSeek 官方 CNY 定价（可热改），提供 record_cost/query_cost/set_budget 三个 agent 工具 + /api/cost-ledger/* HTTP API 供 WebUI 仪表盘 | ✅ |
 | dsh-mdbox | [Chi-hong22/dsh-mdbox](https://github.com/Chi-hong22/dsh-mdbox) | DSH Web 输入框 Markdown 编辑辅助：Shift+Enter 列表续行与空项退出、有序列表自动重编号、Tab/Shift+Tab 双向缩进；纯客户端零运行时依赖，不碰文件/网络/凭据 | 待测 |
-| vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;可选设置页 UI(真实会话闭环实测:发现/连接/增删/别名预填) | ✅ |
+| vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),8 个 vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;ProxyJump/ProxyCommand、Windows 密钥认证、i18n 设置页 UI;npm 包 dsh-vps-hub(v0.1.8) | ✅ |
 | dsh-latexcp | [Chi-hong22/dsh-latexcp](https://github.com/Chi-hong22/dsh-latexcp) | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式复制按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式 | 待测 |
 | dsh-plugin-web-access | [junhongchashui/dsh-plugin-web-access](https://github.com/junhongchashui/dsh-plugin-web-access) | 纯本地按需网页访问：web_fetch 命令行抓取 + 无头浏览器（browser_open/snapshot/eval/screenshot）双通道，零 API Key，注册 ctx.web fetch provider | ✅ |
 | dsh-web-access | [NexusAgentX/dsh-web-access](https://github.com/NexusAgentX/dsh-web-access) | 多提供方联网：web_search / fetch_content / source_check，注册 ctx.web 的 web-access 搜索/抓取提供方，Web 面板改配置与策展；npm `dsh-web-access` | ✅ |


### PR DESCRIPTION
## 变更内容

PLUGINS.md 中 vpshub 条目从 0.1.0 时代的描述更新为 **0.1.8** 现状:

| 插件 | 仓库 | 说明 |
|---|---|---|
| vpshub | [Sdongmaker/vpshub](https://github.com/Sdongmaker/vpshub) | DSH 的 VPS Hub:本地 SSH 台账(Orca 风格 ssh-config/manual + tombstone),8 个 vps_* 工具让 AI 发现/测试/执行/传输,密钥仅路径引用;ProxyJump/ProxyCommand、Windows 密钥认证、i18n 设置页 UI;npm 包 dsh-vps-hub(v0.1.8) |

## 版本信息

- **当前发布版本:0.1.8**(npm `dsh-vps-hub`,2026-08-14 发布)
- 0.1.5–0.1.8 关键变化:完整 proxyCommand 导入、strictHostKeyChecking、密钥路径边界清理、i18n 设置页 UI、Windows 密钥认证、npm 包包含 examples、lossless 工具结果归一化、修复 i18n 重构改名连带损坏

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic(另附 deepseek-harness / cordis / ssh / vps)
- [x] 运行时依赖已声明(`peerDependencies`: @deepseek-ai/cordis、@deepseek-ai/dsh-tools;`dependencies`: zod)
- [x] 真实 DSH Web 会话运行级实测:8 个 vps_* 工具端到端(导入/添加/列表/测试/执行/上传下载/删除)+ 设置页 UI 闭环
- [x] 已勾选 **Allow edits from maintainers**(--maintainer-can-modify)

## 备注

- PLUGINS.md 无独立版本列,版本信息标注在描述末尾 npm 包名旁;如需调整格式可告知
