### PR TITLE
docs: 登记 dsh-llm-fallback

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -48,6 +48,7 @@
 | dsh-latexcp | [Chi-hong22/dsh-latexcp](https://github.com/Chi-hong22/dsh-latexcp) | DSH Web 界面 LaTeX 公式复制插件：悬停 KaTeX 公式复制按钮，一键复制 TeX 源码（$…$ / \(…\) 两种格式 | 待测 |
 | dsh-plugin-web-access | [junhongchashui/dsh-plugin-web-access](https://github.com/junhongchashui/dsh-plugin-web-access) | 纯本地按需网页访问：web_fetch 命令行抓取 + 无头浏览器（browser_open/snapshot/eval/screenshot）双通道，零 API Key，注册 ctx.web fetch provider | ✅ |
 | dsh-web-access | [NexusAgentX/dsh-web-access](https://github.com/NexusAgentX/dsh-web-access) | 多提供方联网：web_search / fetch_content / source_check，注册 ctx.web 的 web-access 搜索/抓取提供方，Web 面板改配置与策展；npm `dsh-web-access` | ✅ |
+| dsh-llm-fallback | [Visol-456/dsh-llm-fallback](https://github.com/Visol-456/dsh-llm-fallback) | LLM 回退链插件：请求本身永远是链头（聊天栏所选模型永不被改写），失败自动按备用顺序切换重试；Web UI 配置面板（provider/model 下拉选择、错误码、阈值、冷却，保存热生效）；dsh.bundle 一键激活；69 单测全绿 + Windows 实测 | ✅ |
 | dsh-lens | [NexusAgentX/dsh-lens](https://github.com/NexusAgentX/dsh-lens) | 写/改文件时的实时代码反馈：LSP / linter / formatter / ast-grep / symbol_search，Web chip+dock；npm `dsh-lens` | ✅ |
 | dsh-mnemon | [omdsh-dev/dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 深度集成的本地记忆系统：运行时热记忆 / 项目档案 / 长期记忆体三层存储，受监督写回、检索工具与 8 页 Web UI | ✅ |
 | dsh-daily-brief | [Equinox7379/dsh-daily-brief](https://github.com/Equinox7379/dsh-daily-brief) | 回合日报：跨 live 会话统计回合/用户消息/助手回复/工具调用（daily_brief 工具，只读零依赖） | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-llm-fallback |
| 仓库 | https://github.com/Visol-456/dsh-llm-fallback |
| 一句话说明 | LLM 回退链插件：请求本身永远是链头（UI 所选模型永不被改写），失败自动按备用顺序切换重试，带 Web UI 配置面板 |
| 版本 | 0.1.1 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@visol-456/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（或已在 fork Settings → General 开启同项，一次开启后续自动生效）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已按自检三步实测通过：

```bash
# 1. 安装最新 dsh 并加载你的插件
node --import tsx/esm apps/cli/src/bin.ts web --patch cordis.yml
# 2. 无报错即通过加载级
# 3. 声明所有运行时依赖（react 等）到 package.json dependencies
```

- [x] 自检结果贴这里：Windows 实测通过——插件加载成功、HTTP 桥 /llm-fallback/config 正常、Web UI 配置面板可用（Settings → 回退链）、fallback 切换实测生效（主模型配错后自动切备用）；69 单元测试全绿（vitest）

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-llm-fallback | [Visol-456/dsh-llm-fallback](https://github.com/Visol-456/dsh-llm-fallback) | LLM 回退链插件：请求本身永远是链头（聊天栏所选模型永不被改写），失败自动按备用顺序切换重试；Web UI 配置面板（provider/model 下拉选择、错误码、阈值、冷却，保存热生效）；dsh.bundle 一键激活；69 单测全绿 + Windows 实测 |

## 备注

- 已发布到 npm（`@visol-456/dsh-llm-fallback`，0.1.1），声明 `dsh.bundle`，`dsh plugin add` 即自动激活
- 中文圈第一个带 Web UI 配置面板的 fallback 类插件；双语 README
- 验证细节：69 单测（circuit/fallback/settings/invariant/loader-composition/transport-recovery）+ Windows 真实 profile 实测（加载、配置热生效、切换行为）
