### PR TITLE
docs: 登记 logicprobe 与 embedded-workbench

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -62,6 +62,8 @@
 | dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审；原生实现于 DSH 扩展点（技能/工具策略/审批 seam/会话日志） | 待测 |
 
 | dsh-mcp-adapter | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | 一个 mcp 代理工具：按需 search/describe/call，不把每个 MCP schema 塞进上下文；Web `/mcp` 菜单可添加/连接/授权 | ✅ |
+| logicprobe | [AmethystLuna/logicprobe](https://github.com/AmethystLuna/logicprobe) | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 | ✅ |
+| embedded-workbench | [AmethystLuna/embedded-workbench](https://github.com/AmethystLuna/embedded-workbench) | 嵌入式 C/C++ 固件工程插件：8 skills（FreeRTOS/Keil/ARMCLANG/HardFault/状态机/LVGL/架构），dsh 原生 bundle 注入会话启动纪律门（1% Rule / Red Flags / Plan Verification Gate） | ✅ |
 | dsh-ci-doctor | [jkrandom-sudo/dsh-ci-doctor](https://github.com/jkrandom-sudo/dsh-ci-doctor) | CI 失败自动诊断：ci_watch 后台监视新增失败运行（基线对比/退避/可取消）+ ci_diagnose 日志签名提取分类（嫌疑文件/裁剪摘录/markdown 诊断卡）+ 失败签名账本去重复发；102 单测 + web profile 进程内 boot 19 项 + headless 真实模型回路实测（v0.1.2 审查修复版） | ✅ |
 
 | dsh-hdc-bridge | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 鸿蒙设备桥：hdc 设备闭环（截图/装包/日志/崩溃/UI 自动化）+ 官方优先 API 知识层（SDK .d.ts + 离线 Tier-1 随包）+ DevEco CLI 构建/签名/lint；无头 DSH 实例真实 E2E 已验证 | ✅ |

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -72,29 +72,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-14 13:58。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-14 15:00。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 1704 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 802 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 3 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 685 | 一个侧边栏的完整工作台，支持三方拓展注册新Tab页面，内置文件渲染编辑/终端/Git/子代理 |
-| 4 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 573 | Open-source CMA-compatible agent runtime for any model,… |
-| 5 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 310 | 是兄弟就来蹬我！DSH Web UI 广告：2005 年中文站点风格的侧栏广告 / 对话内信息流 / 角落弹窗… |
-| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 160 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 7 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 125 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 8 | [whale-girl](https://github.com/vlln/whale-girl) | 118 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 9 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 78 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 10 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 71 | GenUI for DeepSeek Harness: interactive UI components r… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 1759 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 827 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 3 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 702 | 一个侧边栏的完整工作台，支持三方拓展注册新Tab页面，内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 574 | Open-source CMA-compatible agent runtime for any model,… |
+| 5 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 318 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 161 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 7 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 130 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 8 | [whale-girl](https://github.com/vlln/whale-girl) | 120 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 9 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 80 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 10 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 72 | GenUI for DeepSeek Harness: interactive UI components r… |
 | 11 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | 64 | OpenPencil design preview and editing plugin for DSH |
 | 12 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 54 | 把Claude Code的UltraCode模式带给DSH，把 DSH 的一次性多 Agent 调度，升级为可… |
-| 13 | [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 47 | 为 DeepSeek Harness 带来「跨会话长期记忆 + 后台自我进化」能力的纯插件实现：五轨记忆 · … |
+| 13 | [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 49 | 为 DeepSeek Harness 带来「跨会话长期记忆 + 后台自我进化」能力的纯插件实现：五轨记忆 · … |
 | 14 | [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 39 | DSH Web 选中批注插件：选文字→批注→回车随消息发送；气泡隐藏批注块（零闪烁）；回复按 Annotati… |
-| 15 | [plugin-registry](https://github.com/vlln/plugin-registry) | 31 | DSH 插件生态基建：薄控制台（浏览器面板管理官方 repository 插件，0 patch）+ make-… |
-| 16 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 29 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 17 | [ui-status-label](https://github.com/alingalingling/ui-status-label) | 28 | 把你鲸鱼娘思考时的 deep diving 自定义成任意你想要的样子 |
-| 18 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 27 | 【求⭐】🐋DSH Web UI 全手绘像素鲸鱼伙伴插件：会话标题栏常驻，平时眨眼/偶尔摆尾/动胸鳍，思考运行时… |
-| 19 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | 27 | Support dsh runtime on Multica. |
+| 15 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 34 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 16 | [plugin-registry](https://github.com/vlln/plugin-registry) | 32 | DSH 插件生态基建：薄控制台（浏览器面板管理官方 repository 插件，0 patch）+ make-… |
+| 17 | [ui-status-label](https://github.com/alingalingling/ui-status-label) | 29 | 把你鲸鱼娘思考时的 deep diving 自定义成任意你想要的样子 |
+| 18 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | 28 | Support dsh runtime on Multica. |
+| 19 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 27 | 【求⭐】🐋DSH Web UI 全手绘像素鲸鱼伙伴插件：会话标题栏常驻，平时眨眼/偶尔摆尾/动胸鳍，思考运行时… |
 | 20 | [dsh-work](https://github.com/vibeinging/dsh-work) | 25 | Local-first AI workbench for DSH Plugins, combining Age… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -72,29 +72,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-14 13:58。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-14 15:00。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 1704 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 802 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 3 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 685 | 一个侧边栏的完整工作台，支持三方拓展注册新Tab页面，内置文件渲染编辑/终端/Git/子代理 |
-| 4 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 573 | Open-source CMA-compatible agent runtime for any model,… |
-| 5 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 310 | 是兄弟就来蹬我！DSH Web UI 广告：2005 年中文站点风格的侧栏广告 / 对话内信息流 / 角落弹窗… |
-| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 160 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 7 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 125 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 8 | [whale-girl](https://github.com/vlln/whale-girl) | 118 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 9 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 78 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 10 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 71 | GenUI for DeepSeek Harness: interactive UI components r… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 1759 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 827 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 3 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 702 | 一个侧边栏的完整工作台，支持三方拓展注册新Tab页面，内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 574 | Open-source CMA-compatible agent runtime for any model,… |
+| 5 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 318 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 6 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 161 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 7 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 130 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 8 | [whale-girl](https://github.com/vlln/whale-girl) | 120 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 9 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 80 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 10 | [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 72 | GenUI for DeepSeek Harness: interactive UI components r… |
 | 11 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | 64 | OpenPencil design preview and editing plugin for DSH |
 | 12 | [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 54 | 把Claude Code的UltraCode模式带给DSH，把 DSH 的一次性多 Agent 调度，升级为可… |
-| 13 | [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 47 | 为 DeepSeek Harness 带来「跨会话长期记忆 + 后台自我进化」能力的纯插件实现：五轨记忆 · … |
+| 13 | [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 49 | 为 DeepSeek Harness 带来「跨会话长期记忆 + 后台自我进化」能力的纯插件实现：五轨记忆 · … |
 | 14 | [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 39 | DSH Web 选中批注插件：选文字→批注→回车随消息发送；气泡隐藏批注块（零闪烁）；回复按 Annotati… |
-| 15 | [plugin-registry](https://github.com/vlln/plugin-registry) | 31 | DSH 插件生态基建：薄控制台（浏览器面板管理官方 repository 插件，0 patch）+ make-… |
-| 16 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 29 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 17 | [ui-status-label](https://github.com/alingalingling/ui-status-label) | 28 | 把你鲸鱼娘思考时的 deep diving 自定义成任意你想要的样子 |
-| 18 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 27 | 【求⭐】🐋DSH Web UI 全手绘像素鲸鱼伙伴插件：会话标题栏常驻，平时眨眼/偶尔摆尾/动胸鳍，思考运行时… |
-| 19 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | 27 | Support dsh runtime on Multica. |
+| 15 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 34 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 16 | [plugin-registry](https://github.com/vlln/plugin-registry) | 32 | DSH 插件生态基建：薄控制台（浏览器面板管理官方 repository 插件，0 patch）+ make-… |
+| 17 | [ui-status-label](https://github.com/alingalingling/ui-status-label) | 29 | 把你鲸鱼娘思考时的 deep diving 自定义成任意你想要的样子 |
+| 18 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | 28 | Support dsh runtime on Multica. |
+| 19 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 27 | 【求⭐】🐋DSH Web UI 全手绘像素鲸鱼伙伴插件：会话标题栏常驻，平时眨眼/偶尔摆尾/动胸鳍，思考运行时… |
 | 20 | [dsh-work](https://github.com/vibeinging/dsh-work) | 25 | Local-first AI workbench for DSH Plugins, combining Age… |
 
 <!-- AUTO:featured:END -->


### PR DESCRIPTION
> 📌 本 PR 一次登记两个插件（logicprobe + embedded-workbench），均按下方自检清单逐项确认。

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | logicprobe |
| 仓库 | https://github.com/AmethystLuna/logicprobe |
| 一句话说明 | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 |
| 版本 | 0.1.0 |

| 项 | 值 |
|---|---|
| 插件名 | embedded-workbench |
| 仓库 | https://github.com/AmethystLuna/embedded-workbench |
| 一句话说明 | 嵌入式 C/C++ 固件工程插件：8 skills（FreeRTOS/Keil/ARMCLANG/HardFault/状态机/LVGL/架构），dsh 原生 bundle 注入会话启动纪律门（1% Rule / Red Flags / Plan Verification Gate） |
| 版本 | 0.6.0 |

## 自检清单（提交前逐项确认）

- [x] package.json 
ame 使用裸名（logicprobe / embedded-workbench），未占用 @dsh-external/* / @deepseek-ai/* 保留命名空间（按仓库 README 约定，@dsh-external/* 仅限 org 维护者使用）
- [x] 仓库已打 dsh-plugin topic（两仓库均已勾选，经 GitHub API 核实）
- [x] 所有运行时依赖已声明（dependencies: @deepseek-ai/schemastery；peerDependencies: @deepseek-ai/cordis / @deepseek-ai/dsh-agent / @deepseek-ai/dsh-llm / @deepseek-ai/dsh-session）
- [x] 加载级实测通过：gate bundle 已于 2026-08-14 在真实 dsh 会话加载运行——host provider logicprobe / embedded-workbench 可见（cordis_inspect），status 查询正常，会话启动 gate 注入生效
- [x] Allow edits from maintainers：API 无法代勾，需在 PR 页面手动勾选（如需 rebase 协助，请直接留言，我会配合）

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| logicprobe | [AmethystLuna/logicprobe](https://github.com/AmethystLuna/logicprobe) | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 |
| embedded-workbench | [AmethystLuna/embedded-workbench](https://github.com/AmethystLuna/embedded-workbench) | 嵌入式 C/C++ 固件工程插件：8 skills（FreeRTOS/Keil/ARMCLANG/HardFault/状态机/LVGL/架构），dsh 原生 bundle 注入会话启动纪律门（1% Rule / Red Flags / Plan Verification Gate） |

## 备注

- 本次为恢复登记：两条条目此前经 PR #80 / #81 合并，随后在「乱码修复」提交 f518fd6baf 中被一并移除，现已在与上游同步后的 main 上重新登记（干净 UTF-8）。
- 原生 dsh 支持：根 package.json 声明 dsh.bundle（cordis patch），会话启动 gate 注入；skill 由 dsh 的 skill-filesystem 提供方直接发现，零代码。
- 已在 README Requirements 声明支持的 DSH 版本：mainline 2026-08-14 实测。