### PR TITLE
docs: 登记 logicprobe 与 embedded-workbench

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -62,6 +62,8 @@
 | dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审；原生实现于 DSH 扩展点（技能/工具策略/审批 seam/会话日志） | 待测 |
 
 | dsh-mcp-adapter | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | 一个 mcp 代理工具：按需 search/describe/call，不把每个 MCP schema 塞进上下文；Web `/mcp` 菜单可添加/连接/授权 | ✅ |
+| logicprobe | [AmethystLuna/logicprobe](https://github.com/AmethystLuna/logicprobe) | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 | ✅ |
+| embedded-workbench | [AmethystLuna/embedded-workbench](https://github.com/AmethystLuna/embedded-workbench) | 嵌入式 C/C++ 固件工程插件：8 skills（FreeRTOS/Keil/ARMCLANG/HardFault/状态机/LVGL/架构），dsh 原生 bundle 注入会话启动纪律门（1% Rule / Red Flags / Plan Verification Gate） | ✅ |
 | dsh-ci-doctor | [jkrandom-sudo/dsh-ci-doctor](https://github.com/jkrandom-sudo/dsh-ci-doctor) | CI 失败自动诊断：ci_watch 后台监视新增失败运行（基线对比/退避/可取消）+ ci_diagnose 日志签名提取分类（嫌疑文件/裁剪摘录/markdown 诊断卡）+ 失败签名账本去重复发；102 单测 + web profile 进程内 boot 19 项 + headless 真实模型回路实测（v0.1.2 审查修复版） | ✅ |
 
 | dsh-hdc-bridge | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 鸿蒙设备桥：hdc 设备闭环（截图/装包/日志/崩溃/UI 自动化）+ 官方优先 API 知识层（SDK .d.ts + 离线 Tier-1 随包）+ DevEco CLI 构建/签名/lint；无头 DSH 实例真实 E2E 已验证 | ✅ |


### PR DESCRIPTION
> 📌 本 PR 一次登记两个插件（logicprobe + embedded-workbench），均按下方自检清单逐项确认。

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | logicprobe |
| 仓库 | https://github.com/AmethystLuna/logicprobe |
| 一句话说明 | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 |
| 版本 | 0.1.0 |

| 项 | 值 |
|---|---|
| 插件名 | embedded-workbench |
| 仓库 | https://github.com/AmethystLuna/embedded-workbench |
| 一句话说明 | 嵌入式 C/C++ 固件工程插件：8 skills（FreeRTOS/Keil/ARMCLANG/HardFault/状态机/LVGL/架构），dsh 原生 bundle 注入会话启动纪律门（1% Rule / Red Flags / Plan Verification Gate） |
| 版本 | 0.6.0 |

## 自检清单（提交前逐项确认）

- [x] package.json 
ame 使用裸名（logicprobe / embedded-workbench），未占用 @dsh-external/* / @deepseek-ai/* 保留命名空间（按仓库 README 约定，@dsh-external/* 仅限 org 维护者使用）
- [x] 仓库已打 dsh-plugin topic（两仓库均已勾选，经 GitHub API 核实）
- [x] 所有运行时依赖已声明（dependencies: @deepseek-ai/schemastery；peerDependencies: @deepseek-ai/cordis / @deepseek-ai/dsh-agent / @deepseek-ai/dsh-llm / @deepseek-ai/dsh-session）
- [x] 加载级实测通过：gate bundle 已于 2026-08-14 在真实 dsh 会话加载运行——host provider logicprobe / embedded-workbench 可见（cordis_inspect），status 查询正常，会话启动 gate 注入生效
- [x] Allow edits from maintainers：API 无法代勾，需在 PR 页面手动勾选（如需 rebase 协助，请直接留言，我会配合）

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| logicprobe | [AmethystLuna/logicprobe](https://github.com/AmethystLuna/logicprobe) | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 |
| embedded-workbench | [AmethystLuna/embedded-workbench](https://github.com/AmethystLuna/embedded-workbench) | 嵌入式 C/C++ 固件工程插件：8 skills（FreeRTOS/Keil/ARMCLANG/HardFault/状态机/LVGL/架构），dsh 原生 bundle 注入会话启动纪律门（1% Rule / Red Flags / Plan Verification Gate） |

## 备注

- 本次为恢复登记：两条条目此前经 PR #80 / #81 合并，随后在「乱码修复」提交 f518fd6baf 中被一并移除，现已在与上游同步的基础上重新登记（干净 UTF-8）。
- 原生 dsh 支持：根 package.json 声明 dsh.bundle（cordis patch），会话启动 gate 注入；skill 由 dsh 的 skill-filesystem 提供方直接发现，零代码。
- 已在 README Requirements 声明支持的 DSH 版本：mainline 2026-08-14 实测。