### PR TITLE
docs: 登记 dsh-onebot

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -82,6 +82,7 @@
 | dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | ✅ |
 | dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | ✅ |
 | dsh-wechat-bridge | [gtaifu/dsh-wechat-bridge](https://github.com/gtaifu/dsh-wechat-bridge) | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw |
+| dsh-onebot | [mario841859784/dsh-onebot](https://github.com/mario841859784/dsh-onebot) | QQ 渠道插件（OneBot 11 / NapCat）：反向/正向 WS、dm/群聊访问策略与 @ 门控、入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发+撤回（99 测试全绿，真实 QQ 链路实测） |
 
 ## 🛠 基础设施
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-onebot |
| 仓库 | https://github.com/mario841859784/dsh-onebot |
| 一句话说明 | QQ 渠道插件（OneBot 11 / NapCat）：入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（或已在 fork Settings → General 开启同项，一次开启后续自动生效）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已按自检三步实测通过：

```bash
# 1. 安装最新 dsh 并加载你的插件
# 本插件当前即运行在真实 dsh web 宿主上（本 QQ 会话经 dsh-onebot + NapCat 收发，
# 含四类入站媒体解析、语音转写、loop 合并转发+撤回、t2i 卡片实测）
# 2. 加载级无报错；99/99 vitest 全绿（10 test files）
# 3. 运行时依赖已声明：ws / @napi-rs/canvas / fontkit / schemastery（@deepseek-ai/* 为 peerDependencies）
```

- [x] 自检结果：加载成功（真实宿主 + NapCat 链路），99/99 vitest 全绿，入站媒体四类实测通过

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-onebot | https://github.com/mario841859784/dsh-onebot | QQ 渠道插件（OneBot 11 / NapCat）：反向/正向 WS、dm/群聊访问策略与 @ 门控、入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发+撤回（99 测试全绿，真实 QQ 链路实测） |

## 备注

- 包名刚按生态约定从 `dsh-onebot` 改为 `@dsh-external/dsh-onebot`（npm 未占用，未触碰保留命名空间）
- 与 `dsh-telegram` / `dsh-lark-bot` / `dsh-wechat-bridge` 同类：OneBot 11 协议，兼容 NapCat / Lagrange / LLOneBot / go-cqhttp
