### PR TITLE
docs: 登记 dsh-agent-preset-recommender

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -65,6 +65,7 @@
 | dsh-ci-doctor | [jkrandom-sudo/dsh-ci-doctor](https://github.com/jkrandom-sudo/dsh-ci-doctor) | CI 失败自动诊断：ci_watch 后台监视新增失败运行（基线对比/退避/可取消）+ ci_diagnose 日志签名提取分类（嫌疑文件/裁剪摘录/markdown 诊断卡）+ 失败签名账本去重复发；102 单测 + web profile 进程内 boot 19 项 + headless 真实模型回路实测（v0.1.2 审查修复版） | ✅ |
 
 | dsh-hdc-bridge | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 鸿蒙设备桥：hdc 设备闭环（截图/装包/日志/崩溃/UI 自动化）+ 官方优先 API 知识层（SDK .d.ts + 离线 Tier-1 随包）+ DevEco CLI 构建/签名/lint；无头 DSH 实例真实 E2E 已验证 | ✅ |
+| dsh-agent-preset-recommender | [LeemanCheung/dsh-agent-preset-recommender](https://github.com/LeemanCheung/dsh-agent-preset-recommender) | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset | 待测 |
 ## 🧰 插件集
 
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-agent-preset-recommender |
| 仓库 | https://github.com/LeemanCheung/dsh-agent-preset-recommender |
| 一句话说明 | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset。 |
| 版本 | 0.1.6 |

## 自检清单

- [x] 使用非保留包名 `dsh-agent-preset-recommender`，不占用 `@deepseek-ai/*`
- [x] 仓库已打 `dsh-plugin` topic
- [x] 运行时依赖已在 `dependencies` / `peerDependencies` 声明
- [x] `npm test` 通过（25 个合成 fixture：DSH preset 语义、隐私、Codex typed tool、Claude child-session 去重、超大 JSONL 前缀采样、workflow sidecar 排除、输入验证、取消写入、排队调用快速取消、调度合并、同回合卸载、报告验证、生命周期）
- [x] `npm pack --dry-run` 通过

加载级 DSH profile 实测留给雷达验证，故登记状态为“待测”。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-agent-preset-recommender | https://github.com/LeemanCheung/dsh-agent-preset-recommender | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset |

## 备注

默认只保留分类工具计数、会话/workflow/元数据数量、日期和本机私有 HMAC 派生的项目 ID；不保存 prompt、回复、命令、工具参数、绝对路径或 secret。Claude/CodeBuddy workflow 脚本、sidecar 与 journal 有意不读取；WorkBuddy session 文件识别是版本敏感的启发式，而非 CodeBuddy session 等价证明。`code` 是 `standard` 的展示变体，不从扫描量自动推断。