### PR TITLE
docs: 更新 dsh-lark-bot 至 0.6.0（bundle 可安装、并行、角色、归档、跨会话通知）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -87,7 +87,7 @@
 
 | dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps |
 | dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | ✅ |
-| dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | ✅ |
+| dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知；npm 双包 + dsh profile bundle 可安装（0.6.0） |
 | dsh-wechat-bridge | [gtaifu/dsh-wechat-bridge](https://github.com/gtaifu/dsh-wechat-bridge) | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw |
 | dsh-onebot | [mario841859784/dsh-onebot](https://github.com/mario841859784/dsh-onebot) | QQ 渠道插件（OneBot 11 / NapCat）：反向/正向 WS、dm/群聊访问策略与 @ 门控、入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发+撤回（99 测试全绿，真实 QQ 链路实测） |
 

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ graph TB
 | [dsh-feishu-plugin](https://github.com/yangzhaofeng496/dsh-feishu-plugin) | 社区 | ✅ 运行级可用 | Feishu bot bridge plugin for DeepSeek Harness |
 | [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) | 社区 | ✅ 运行级可用 | Multi-platform IM gateway for DeepSeek Harness: Feishu (Lark), WeCom (WeChat Wor |
 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | 社区 | ✅ 运行级可用 | Lark/Feishu IM bot channel for DeepSeek Harness \| 飞书 DeepSeek Harness 插件 |
-| [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | 社区 | ✅ 运行级可用 | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot，含完整项目工作区管理 |
+| [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | 社区 | ✅ 运行级可用 | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知；npm 双包 + dsh profile bundle 可安装（0.6.0） |
 | [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) | 社区 | ✅ 运行级可用 | — |
 | [dsh-llm-codex-oauth](https://github.com/Player-MINEPIG/dsh-llm-codex-oauth) | 社区 | ✅ 运行级可用 | 在 dsh（DeepSeek Harness）里使用你的 ChatGPT / Codex 订阅 |
 | [dsh-llm-proxy](https://github.com/Ye-Yu-Mo/dsh-llm-proxy) | 社区 | ✅ 运行级可用 | DeepSeek Harness (dsh) 全局 HTTP 代理插件：undici setGlobalDispatcher + EnvHttpProxyAge |


### PR DESCRIPTION
## 更新内容

将 `dsh-lark-bot` 条目从「仅项目工作区管理」更新为 **0.6.0** 完整能力：

- 流式卡片、git worktree 项目隔离、官方 dsh SDK / ACP 后端（不变）
- **scope 并行任务**（默认 2 个 run 并行，`/concurrency` 可调）
- **多角色 Agent**（`/role`：persona / 模型 / 工具指引 / 角色规则，按 scope 绑定）
- **会话 / 任务归档**（`/archive` + `/retention`，Markdown + JSONL + Git commit）
- **出站 @ 提及与跨会话通知**（`/notify` + agent 侧 `lark_notify` dsh 工具）
- **dsh profile bundle 可安装**（`dsh.bundle.patch` 已声明，`dsh plugin --profile <name> add dsh-lark-bot` 实测通过）
- npm 双包 `dsh-lark-bot` / `dsh-feishu-bot` 已发布 **0.6.0**（均带 bundle 清单）

## 改动文件

- `README.md`：更新单插件表格中 dsh-lark-bot 行的说明
- `PLUGINS.md`：更新「📡 远程渠道」中 dsh-lark-bot 行的说明

## 验证

- `dsh plugin --profile demo add dsh-lark-bot-0.6.0.tgz` 实测通过（`dsh.profile.bundles` 追加成功）
- `dsh --profile demo --dump-config` 可见 `# == dsh-lark-bot` 层
- 兼容矩阵：dsh 0.1.0-rc.6（`pnpm release:check` 通过）
