### PR TITLE
docs: 更新 dsh-lark-bot 至 0.7.0（唯一路径：dsh bundle 进程内运行桥接引擎）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -87,7 +87,7 @@
 
 | dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps | 待测 |
 | dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | ✅ | ✅ |
-| dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | ✅ | ✅ |
+| dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 标准 dsh profile bundle（`dsh plugin add` 一行安装），桥接引擎在 dsh 进程内运行；流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知（0.7.0） | ✅ |
 | dsh-wechat-bridge | [gtaifu/dsh-wechat-bridge](https://github.com/gtaifu/dsh-wechat-bridge) | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw | ❌ |
 | dsh-onebot | [mario841859784/dsh-onebot](https://github.com/mario841859784/dsh-onebot) | QQ 渠道插件（OneBot 11 / NapCat）：反向/正向 WS、dm/群聊访问策略与 @ 门控、入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发+撤回（99 测试全绿，真实 QQ 链路实测） | 待测 |
 

--- a/README.md
+++ b/README.md
@@ -838,7 +838,7 @@ graph TB
 | [dsh-feishu-plugin](https://github.com/yangzhaofeng496/dsh-feishu-plugin) | 社区 | ✅ 运行级可用 | Feishu bot bridge plugin for DeepSeek Harness |
 | [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) | 社区 | ✅ 运行级可用 | Multi-platform IM gateway for DeepSeek Harness: Feishu (Lark), WeCom (WeChat Wor |
 | [dsh-lark](https://github.com/omdsh-dev/dsh-lark) | 社区 | ✅ 运行级可用 | Lark/Feishu IM bot channel for DeepSeek Harness \| 飞书 DeepSeek Harness 插件 |
-| [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | 社区 | ✅ 运行级可用 | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot，含完整项目工作区管理 |
+| [dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | 社区 | ✅ 运行级可用 | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 标准 dsh profile bundle（`dsh plugin add` 一行安装），桥接引擎在 dsh 进程内运行；流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知（0.7.0） |
 | [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) | 社区 | ✅ 运行级可用 | — |
 | [dsh-llm-codex-oauth](https://github.com/Player-MINEPIG/dsh-llm-codex-oauth) | 社区 | ✅ 运行级可用 | 在 dsh（DeepSeek Harness）里使用你的 ChatGPT / Codex 订阅 |
 | [dsh-llm-proxy](https://github.com/Ye-Yu-Mo/dsh-llm-proxy) | 社区 | ✅ 运行级可用 | DeepSeek Harness (dsh) 全局 HTTP 代理插件：undici setGlobalDispatcher + EnvHttpProxyAge |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-lark-bot |
| 仓库 | https://github.com/PlutoKeating/dsh-lark-bot |
| 一句话说明 | 把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 标准 dsh profile bundle（`dsh plugin add` 一行安装），桥接引擎在 dsh 进程内作为标准插件运行；流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知 |
| 版本 | 0.7.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用**自有命名空间** `dsh-lark-bot`（未占用 `@dsh-external/*` 或 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 fork Settings → General 开启 **Allow edits and access to secrets by maintainers**
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`：`@larksuite/channel`、`@deepseek-ai/dsh-sdk-client`、`@agentclientprotocol/sdk`、`@deepseek-ai/cordis` 等）
- [x] 自检三步实测：`dsh plugin --profile demo add dsh-lark-bot@0.7.0` 成功（bundles 追加 `dsh-lark-bot`）；`dsh --profile demo --dump-config` 出现 `# == dsh-lark-bot` 层（`dsh-lark-bot/plugin` + `lark-notify` 两行）；`dsh --profile headless "hi"` 以标准插件装载并进程内启动桥接引擎（首次启动打印扫码向导），无加载错误
- [x] README 已按目录「给插件开发者」九章节 + omdsh 收录要求补齐（Install/Uninstall/Upgrade/Disable、回滚、维护者、已知限制、版权等）

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-lark-bot | https://github.com/PlutoKeating/dsh-lark-bot | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 标准 dsh profile bundle（`dsh plugin add` 一行安装），桥接引擎在 dsh 进程内运行；流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知（0.7.0） |

## 备注

- 本 PR 为**描述/状态更新**（上一版 0.6.0 更新 PR #119 已关闭）：0.7.0 按最终需求收敛为唯一路径
  （独立后台服务层移除，桥接引擎作为 dsh profile bundle 插件在 dsh 进程内运行）。
- 兼容性：dsh 0.1.0-rc.6（最后验证 2026-08-15，`pnpm release:check` 通过）。
- 已知边界见插件 README「已知限制」：ACP 会话全新、SDK 无 mid-turn cancel、嵌套 runtime 取舍等。
