### PR TITLE
docs: 登记 dsh-remotion 与 dsh-hyperframes（视频创作技能插件）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -138,3 +138,10 @@ index 181fc9f..3a2dc13 100644
 ++ b/PLUGINS.md
 @@ -90,6 +90,7 @@
 | dsh-feishucard | [cmfok/dsh-feishucard](https://github.com/cmfok/dsh-feishucard) | DSH ↔ 飞书桥（自研非 fork）：官方 SDK 长连接（无需公网）+ 流式回复卡片（过程话语内联/工具折叠面板/状态符号/限流退避熔断兜底），每聊天独立会话 + live 复用保上下文，配置独立 ~/.dsh-feishucard；npm dsh-feishucard v0.1.0，冒烟 18 项 + 实机链路实测通过 | ✅ |
+diff --git a/PLUGINS.md b/PLUGINS.md
+index 181fc9f..0f2d03d 100644
+--- a/PLUGINS.md
+++ b/PLUGINS.md
+@@ -30,6 +30,8 @@
+| dsh-remotion | [STARDUSTLC666/dsh-remotion](https://github.com/STARDUSTLC666/dsh-remotion) | 视频创作技能插件：注册 Remotion 官方移植技能（React 编程式视频，动画/音频/字幕/3D/图表/字体 + 38 个规则文件），安装即用 | 待测 |
+| dsh-hyperframes | [STARDUSTLC666/dsh-hyperframes](https://github.com/STARDUSTLC666/dsh-hyperframes) | 视频创作技能插件：注册 HyperFrames by HeyGen 官方移植技能五件套（HTML 写视频 / hyperframes CLI / 注册表 / 网址转视频 / GSAP 参考），安装即用 | 待测 |


### PR DESCRIPTION
两个新社区插件（作者 stardustlc，打 dsh-plugin 话题，各 10 测试全绿 + 真实 profile 启动冒烟通过）：

- dsh-remotion：Remotion 官方技能（React 编程式视频，38 规则文件）
- dsh-hyperframes：HyperFrames by HeyGen 五件套（hyperframes / cli / registry / website-to-hyperframes / gsap）

技能以插件形式注册进 ctx.skills，安装即用（无需手工复制技能目录）。