### PR TITLE
docs: 登记 dsh-session-hub

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -93,6 +93,7 @@
 | dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 标准 dsh profile bundle（`dsh plugin add` 一行安装），桥接引擎在 dsh 进程内运行；流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知、安全网守护（dsh 下线后经飞书 /safemode 仅核心自愈）（0.8.0） | ✅ |
 | dsh-wechat-bridge | [gtaifu/dsh-wechat-bridge](https://github.com/gtaifu/dsh-wechat-bridge) | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw | ❌ |
 | dsh-onebot | [mario841859784/dsh-onebot](https://github.com/mario841859784/dsh-onebot) | QQ 渠道插件（OneBot 11 / NapCat）：反向/正向 WS、dm/群聊访问策略与 @ 门控、入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发+撤回（99 测试全绿，真实 QQ 链路实测） | 待测 |
+| dsh-session-hub | [Asaiuta/dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) | 多服务器 DSH 会话聚合与原生操控：网关+官方 UI 桥，一屏合并多个远程 dsh web 的会话，支持历史/prompt/取消/重命名/fork/模型选择/审批问答，并导入本机其他工具的历史会话 | 待测 |
 
 ## 🛠 基础设施
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-session-hub |
| 仓库 | https://github.com/Asaiuta/dsh-session-hub |
| 一句话说明 | 多服务器 DSH 会话聚合与原生操控：网关+官方 UI 桥，一屏合并多个远程 dsh web 的会话，支持历史/prompt/取消/重命名/fork/模型选择/审批问答，并导入本机其他工具的历史会话 |
| 版本 | 0.1.0-alpha.2 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用 `@deepseek-ai/*` 保留命名空间（裸名 `dsh-session-hub`，未用无权持有的 `@dsh-external/*` scope）
- [x] 仓库已打 `dsh-plugin` topic（另有 `dsh`、`deepseek-harness`、`multi-server`、`session-management`、`session-sync`）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（fork PR 默认允许）
- [x] 所有运行时依赖已声明（`dependencies`: zod、ssh2；`peerDependencies`: 11 个 `@deepseek-ai/*` 包 + react，均标可选）
- [x] 自检三步实测通过（安装 → 加载 → 运行）：

```bash
# 1. 打包安装到隔离 profile（等价于 PR 模板的 --profile headless --patch 实测）：
npm pack
npm install dsh-session-hub-0.1.0-alpha.2.tgz   # 装入 profile（bundles: dsh-base + dsh-web-app）
# 2. patch insert dsh-session-hub 后 boot，无任何加载报错，插件正常激活
# 3. 服务启动日志（真机实测输出）：
```

```
dsh web: http://127.0.0.1:3080
[dsh-session-hub] import cache restored 850, total 850
[dsh-session-hub] imported 850 external sessions
```

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-session-hub | [Asaiuta/dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) | 多服务器 DSH 会话聚合与原生操控：网关+官方 UI 桥，一屏合并多个远程 dsh web 的会话，支持历史/prompt/取消/重命名/fork/模型选择/审批问答，并导入本机其他工具的历史会话 |

## 备注

- 插件为双面型（客户端 UI 注入 + host 服务）：在纯 `dsh-base` profile（无 web 宿主）下 cordis 会报 `pending (waiting for services: webServer, apiProxy)`，属预期行为；需在含 `dsh-web-app` bundle 的 profile（如 `web`）中运行，上述实测即在 web 组合下完成。
- 运行级状态暂标「待测」，欢迎雷达 k8s 环境复核（本项目已在同一 dsh 版本 `0.1.0-rc.6` 真机跑通核心链路）。
- `package.json` 提供 `main` + `exports` + `dsh` 字段，B1 静态校验可过。
