### PR TITLE
docs: 登记 dsh-theme-plugin 和 dsh-opencodego-usage

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -135,3 +135,5 @@
 | dsh-voice | [STARDUSTLC666/dsh-voice](https://github.com/STARDUSTLC666/dsh-voice) | 语音双件套：voice_tts（edge-tts 协议免费微软神经语音，Sec-MS-GEC 本地 DRM 生成）/ voice_stt（OpenAI 兼容 ASR）/ voice_list，WS 压缩 + 可选代理隧道 | 待测 |
 | dsh-codex-port | [STARDUSTLC666/dsh-codex-port](https://github.com/STARDUSTLC666/dsh-codex-port) | Codex 技能移植插件：扫描 ~/.codex 把官方 Codex 插件（本机实测 186 个插件/583 技能，一次移植 577 成功）批量转为 DSH 技能（codex_list/port/status），frontmatter 自动转换、幂等跳过 | 待测 |
 | ncm-player | [WolfGenerals/ncm-player](https://github.com/WolfGenerals/ncm-player) | 网易云音乐浮窗播放器：歌单/歌词/歌词翻译/播放队列/账号登录，适配皮肤主题 | 待测 |
+| dsh-theme-plugin | [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) | DSH Web GUI 主题工作室：5 套内置预设（codex-warm / nord / solarized / graphite / stock）+ 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），经官方 theme overrideTokens 即时热切换、localStorage 持久化，纯官方接缝无补丁文件 | 待测 |
+| dsh-opencodego-usage | [BeiZi6/dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) | OpenCodeGo 剩余额度监视器：输入框右下角呼吸灯（按剩余额度绿/黄/红）+ 液态玻璃面板（滚动/周/月三窗口用量与重置时间），每 30 秒自动刷新，Key 自动读取 DSH 凭据（opencode-go 提供商）也可手动覆盖 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-theme-plugin |
| 仓库 | https://github.com/BeiZi6/dsh-theme-plugin |
| 一句话说明 | DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），官方 theme overrideTokens 即时热切换、localStorage 持久化 |
| 版本 | 0.1.0 |

| 项 | 值 |
|---|---|
| 插件名 | dsh-opencodego-usage |
| 仓库 | https://github.com/BeiZi6/dsh-opencodego-usage |
| 一句话说明 | OpenCodeGo 剩余额度监视器：输入框右下角呼吸灯（按剩余额度绿/黄/红）+ 液态玻璃面板（滚动/周/月三窗口用量与重置时间），每 30 秒自动刷新，Key 自动读取 DSH 凭据也可手动覆盖 |
| 版本 | 0.2.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用普通短名（`dsh-theme-plugin` / `dsh-opencodego-usage`），未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies`: `@deepseek-ai/cordis` ^4、`@deepseek-ai/dsh-host-webserver`；`dependencies`: `@deepseek-ai/schemastery`）
- [ ] 自检三步实测：作者本机 web profile 加载与使用通过（主题即时切换生效、额度面板 30s 刷新正常）；headless 命令行实测待维护者按需复验

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-theme-plugin | [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) | DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色，即时热切换、localStorage 持久化，纯官方接缝 |
| dsh-opencodego-usage | [BeiZi6/dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) | OpenCodeGo 剩余额度监视器：呼吸灯 + 三窗口用量面板，30s 自动刷新，Key 自动读取 DSH 凭据 |

## 备注

- 两个插件均为 `dsh.bundle` 清单（`cordis.patch.yml` + web client），安装：`dsh plugin --profile web add github:BeiZi6/dsh-theme-plugin` / `dsh plugin --profile web add github:BeiZi6/dsh-opencodego-usage`
- 运行级列标 `待测`：合并后可按雷达扫描/实测流程验证
