### PR TITLE
docs: 登记 dsh-side-chat

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -75,6 +75,7 @@
 | dsh-hdc-bridge | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 鸿蒙设备桥：hdc 设备闭环（截图/装包/日志/崩溃/UI 自动化）+ 官方优先 API 知识层（SDK .d.ts + 离线 Tier-1 随包）+ DevEco CLI 构建/签名/lint；无头 DSH 实例真实 E2E 已验证 | ✅ |
 | deepseek-skin-studio | [JueMing2049/deepseek-skin-studio](https://github.com/JueMing2049/deepseek-skin-studio) | DSH 换肤工作室：一张图一套皮肤，三通道注入（书签/CDP/原生插件）+ 可视化工坊 + 13 套内置主题 + DSH-SKIN-SPEC 导出 | 待测 |
 | dsh-agent-preset-recommender | [LeemanCheung/dsh-agent-preset-recommender](https://github.com/LeemanCheung/dsh-agent-preset-recommender) | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset | 待测 |
+| dsh-side-chat | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问（按会话隔离，继承主会话模型/思考难度/权限），AI 回复可原文或摘要带回主会话，问题弹框选项可一键带入 | 待测 |
 ## 🧰 插件集
 
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-side-chat |
| 仓库 | https://github.com/heartmove/dsh-side-chat |
| 一句话说明 | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问，AI 回复可原文或摘要带回主会话 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [√] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）— 注：name 为无 scope 的 `dsh-side-chat`，未占用 `@deepseek-ai/*` 保留命名空间
- [√] 仓库已打 `dsh-plugin` topic
- [√] 已在 PR 页面勾选 **Allow edits from maintainers**（本仓库即目标仓库，无 fork；如需要仍可勾选）
- [√] 所有运行时依赖已声明（`peerDependencies` 完整：@deepseek-ai/dsh-* + cordis + react/react-dom）
- [√] 已按自检三步实测通过：
  1. `pnpm install`（prepare 自动构建 lib/）→ `dsh plugin --profile headless add` 安装成功
  2. `dsh --profile headless --patch <insert dsh-side-chat> "hi"`：纯 headless 下按设计 pending（web 插件等待 webServer/workspaceRegistry/agentPresets 服务，证明 loader 与依赖声明正常）；补入 web 服务栈（webserver + workspace + agent-presets + storage）后**加载成功，agent 正常回复（exit 0）**
  3. 依赖声明完整（缺包从未发生，仅缺环境服务）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-side-chat | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问（按会话隔离，继承主会话模型/思考难度/权限），AI 回复可原文或摘要带回主会话，问题弹框选项可一键带入 |

## 备注

- 版本 0.1.0，`dsh.bundle.patch` → `cordis.patch.yml`，`dsh plugin --profile web add github:heartmove/dsh-side-chat` 一键安装
- 插件为 Web 平台插件（`dsh.client.platform: web`），运行级待管道验证