### PR TITLE
docs: 登记 dsh-usage-dashboard

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -139,3 +139,4 @@
 | ncm-player | [WolfGenerals/ncm-player](https://github.com/WolfGenerals/ncm-player) | 网易云音乐浮窗播放器：歌单/歌词/歌词翻译/播放队列/账号登录，适配皮肤主题 | 待测 |
 | dsh-theme-plugin | [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) | DSH Web GUI 主题工作室：5 套内置预设（codex-warm / nord / solarized / graphite / stock）+ 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），经官方 theme overrideTokens 即时热切换、localStorage 持久化，纯官方接缝无补丁文件 | 待测 |
 | dsh-opencodego-usage | [BeiZi6/dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) | OpenCodeGo 剩余额度监视器：输入框右下角呼吸灯（按剩余额度绿/黄/红）+ 液态玻璃面板（滚动/周/月三窗口用量与重置时间），每 30 秒自动刷新，Key 自动读取 DSH 凭据（opencode-go 提供商）也可手动覆盖 | 待测 |
+| dsh-usage-dashboard | [Cassius0924/dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) | DeepSeek 额度与用量仪表盘：悬浮额度窗 + 「额度」tab，余额可用天数、今日/本月消耗环比、模型/会话成本排行、缓存节省、2026-08-17 峰谷定价前后账单对比，估算算法与单价公开在 src/pricing.ts | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-usage-dashboard |
| 仓库 | https://github.com/Cassius0924/dsh-usage-dashboard |
| 一句话说明 | DeepSeek 额度与用量仪表盘：悬浮额度窗 + 「额度」tab，余额可用天数、今日/本月消耗环比、模型/会话成本排行、缓存节省、峰谷定价前后账单对比 |
| 版本 | 0.3.0 |

## 自检清单（提交前逐项确认）

- [ ] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
  - 本插件不属于 `dsh-external` 组织，按 README「给插件开发者」章节的命名规则，使用的是自己有权控制的命名空间 `@cassius0924/dsh-usage-dashboard`，未占用 `@dsh-external/*` 或 `@deepseek-ai/*`。
- [x] 仓库已打 `dsh-plugin` topic（连同 `cordis`/`deepseek`/`deepseek-harness`/`dsh`）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies`：`@deepseek-ai/cordis@^4.0.0`、`react@^18.2.0`；无额外 `dependencies`）
- [ ] 已按自检三步实测通过
  - 本地环境未安装 `dsh` CLI，未跑通 `dsh --profile headless --patch ...` 加载级测试；已在仓库内跑通等价的构建/类型检查（见下方结果），运行级验证烦请雷达自己的 k8s 流程代跑。

- [ ] 自检结果贴这里：
  ```
  $ pnpm install --frozen-lockfile
  Already up to date

  $ pnpm run build
  lib/index.js      15.3kb
  lib/client.js      97.6kb
  ⚡ Done

  $ pnpm run typecheck
  (无输出，通过)
  ```
  未跑 `dsh --profile headless` 加载级测试（本地无 dsh CLI），如实标注为「待测」，请雷达 k8s 实测覆盖。

## 改动内容

PLUGINS.md「🔌 单插件」表格追加一行：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-usage-dashboard | [Cassius0924/dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) | DeepSeek 额度与用量仪表盘：悬浮额度窗 + 「额度」tab，余额可用天数、今日/本月消耗环比、模型/会话成本排行、缓存节省、2026-08-17 峰谷定价前后账单对比，估算算法与单价公开在 src/pricing.ts |

## 备注

- README（中文）已包含：功能概览、安装/卸载（`dsh plugin` 增删）、快速上手、费用估算算法与单价表（`src/pricing.ts`，公开可查）、开发/构建说明、License（MIT）、已知限制。
- 仓库同名冲突提示：目录里已有一条同名条目 `dsh-usage-dashboard` 指向 `1690834643/dsh-usage-dashboard`，与本仓库（`Cassius0924/dsh-usage-dashboard`）是不同项目，请注意区分，勿去重合并。
