### PR TITLE
docs: 登记 dsh-subagent-max

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -76,6 +76,7 @@
 | deepseek-skin-studio | [JueMing2049/deepseek-skin-studio](https://github.com/JueMing2049/deepseek-skin-studio) | DSH 换肤工作室：一张图一套皮肤，三通道注入（书签/CDP/原生插件）+ 可视化工坊 + 13 套内置主题 + DSH-SKIN-SPEC 导出 | 待测 |
 | dsh-agent-preset-recommender | [LeemanCheung/dsh-agent-preset-recommender](https://github.com/LeemanCheung/dsh-agent-preset-recommender) | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset | 待测 |
 | dsh-side-chat | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问（按会话隔离，继承主会话模型/思考难度/权限），AI 回复可原文或摘要带回主会话，问题弹框选项可一键带入 | 待测 |
+| dsh-subagent-max | [aaravarr/dsh-subagent-max](https://github.com/aaravarr/dsh-subagent-max) | 子代理委派按次指定模型/提供商（host 侧 `subagent_with_model` 工具）+ 多面板实时流式子代理查看器（client 侧浮动面板 token 级流式输出、卡片网格、拖拽弹出、中英 i18n）；rc.6 headless 实测通过 | ✅ |
 ## 🧰 插件集
 
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-subagent-max |
| 仓库 | https://github.com/aaravarr/dsh-subagent-max |
| 一句话说明 | 子代理委派按次指定模型/提供商（host 侧 subagent_with_model 工具）+ 多面板实时流式子代理查看器（client 侧） |
| 版本 | 0.1.1 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `@aaravarr/*`（未占用 `@deepseek-ai/*` / `@dsh-external/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic（另有 dsh-plugins / panel / subagents）
- [x] 允许维护者编辑（fork PR 默认开启 maintainer edits）
- [x] 所有运行时依赖已声明：`dependencies` react ^18.2.0；`peerDependencies` @deepseek-ai/cordis ^4.0.1、dsh-client-ui-primitives、dsh-jobs、dsh-subagent、dsh-tools、schemastery
- [x] 自检三步实测通过（dsh 0.1.0-rc.6，Windows）：
  1. `dsh plugin --profile test-max add -w @aaravarr/dsh-subagent-max` 安装成功；
  2. `dsh --profile test-max --dump-config` 正确 compose 出 `# == @aaravarr/dsh-subagent-max` 层（toolName: subagent_with_model，backgroundMode: continuable）；
  3. `dsh --profile test-max "hi"` headless boot 完整跑通（exit 0，模型正常回复）。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-subagent-max | [aaravarr/dsh-subagent-max](https://github.com/aaravarr/dsh-subagent-max) | 子代理委派按次指定模型/提供商 + 多面板实时流式子代理查看器 |

## 备注

- npm 包 `@aaravarr/dsh-subagent-max`（v0.1.1，MIT）；仓库已打 `dsh-plugin` topic，会被每日 02:00 全量扫描自动收录。
- 本次为登记性 PR：仅在 PLUGINS.md「🔌 单插件」分类追加一行，无其他改动。
