### PR TITLE
docs: 登记 dsh-update-notifier

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -80,6 +80,7 @@
 
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |
 | dsh-subagent-cwd | [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) | dsh-subagent-tools 加按次 cwd（子代理工作目录），附两处进程内 provider 补丁；rc.6 前台/后台 cwd 实测通过 | ✅ |
+| dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体更新提醒：npm latest 高于本地版本时侧边栏左下角红点+Modal（复制更新命令/忽略此版本/稍后再说），官方 ui-primitives 渲染，无更新零 UI；零构建、25 单测、rc.5/rc.6 加载与端点 E2E 实测 | 待测 |
 | （暂无手工登记；打标自动收录） | | |
 
 ## 🎓 技能


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-update-notifier |
| 仓库 | https://github.com/arvin-yd/dsh-update-notifier |
| 一句话说明 | DSH 本体更新提醒：npm `latest` 高于本地版本时侧边栏左下角红点 + Modal（复制更新命令 / 忽略此版本 / 稍后再说），官方 ui-primitives 渲染，无更新零 UI |
| 版本 | 0.2.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用非保留命名空间（unscoped `dsh-update-notifier`，未占用 `@deepseek-ai/*`；按雷达规则未获 `dsh-external` 维护权限，故不使用 `@dsh-external/*`）
- [x] 仓库已打 `dsh-plugin` topic（另有 `deepseek-harness`、`update-checker`）
- [x] 已勾选允许维护者修改（PR 创建时 `maintainer_can_modify=true`）
- [x] 所有运行时依赖已声明：`dependencies: { semver }`，`peerDependencies: { @deepseek-ai/cordis }`；浏览器端仅 `react` 与 `@deepseek-ai/dsh-client-ui-primitives`（经 `dsh.client.inject` 组合声明）
- [x] 已按自检三步实测通过：

```bash
# 1. 安装并加载（dsh 0.1.0-rc.5 源码构建 + 0.1.0-rc.6 npm 安装双环境）
dsh plugin --profile headless add https://github.com/arvin-yd/dsh-update-notifier.git
dsh --profile headless "hi"
# 2. 插件零报错加载；唯一错误为测试环境缺失 DEEPSEEK_API_KEY（MISSING_CREDENTIAL，与插件无关）
# 3. 另有 web profile 完整 boot 实测：GET /dsh-update-check 返回
#    {"state":"update-available","current":"0.1.0-rc.5","latest":"0.1.0-rc.6","fetchedAt":...,"error":null,"updateHint":"..."}
```

- [x] 自检结果：**加载级通过**（headless 零插件报错）；**运行级**：web 启动 + 端点响应正确（rc.5 → rc.6 判定 update-available）+ `?force=1` 手动刷新正常 + 日志无告警；25/25 vitest 单测（含 jsdom 注册冒烟测试）。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体更新提醒：npm latest 高于本地版本时侧边栏左下角红点+Modal（复制更新命令/忽略此版本/稍后再说），官方 ui-primitives 渲染，无更新零 UI；零构建、25 单测、rc.5/rc.6 加载与端点 E2E 实测 |

## 备注

- 与已有 `dsh-update-radar`（检测"已装插件"落后）互补：本插件检测的是 **DSH 本体**。
- 版本探测三级回退（插件目录 → 运行 bin → 外围 `@deepseek-ai/dsh*` 包），覆盖 npm/npx/link 安装形态；无遥测、磁盘零写入。
- 已知边界：无自动升级（dsh 无内置 update 命令且重启必须手动），面板提供"复制更新命令"。
