### PR TITLE
docs: 登记 dsh-permission-rules

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -77,6 +77,7 @@
 | dsh-agent-preset-recommender | [LeemanCheung/dsh-agent-preset-recommender](https://github.com/LeemanCheung/dsh-agent-preset-recommender) | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset | 待测 |
 | dsh-side-chat | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问（按会话隔离，继承主会话模型/思考难度/权限），AI 回复可原文或摘要带回主会话，问题弹框选项可一键带入 | 待测 |
 | dsh-subagent-max | [aaravarr/dsh-subagent-max](https://github.com/aaravarr/dsh-subagent-max) | 子代理委派按次指定模型/提供商（host 侧 `subagent_with_model` 工具）+ 多面板实时流式子代理查看器（client 侧浮动面板 token 级流式输出、卡片网格、拖拽弹出、中英 i18n）；rc.6 headless 实测通过 | ✅ |
+| dsh-permission-rules | [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) | Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则，在 tools/pre-execute 瀑布上匹配工具名/参数/工作区路径/agent 身份，带会话日志审计、干跑模式与热重载；npm 已发布 | 待测 |
 ## 🧰 插件集
 
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-permission-rules |
| 仓库 | https://github.com/PerryLink/dsh-permission-rules |
| 一句话说明 | Claude Code 风格声明式权限规则（allow/deny/ask），tools/pre-execute 首匹配 + 会话日志审计 |
| 版本 | 0.4.1 |

## 自检清单（提交前逐项确认）

- [ ] package.json `name` 未使用 `@dsh-external/*`：当前使用自有命名空间 `dsh-permission-rules`（未占用 `@deepseek-ai/*` 保留命名空间），尚未获得 dsh-external 维护权限，获得后迁移（README「给插件开发者」明文：只有获得 dsh-external 维护权限的项目才应使用该 scope）。
- [x] 仓库已打 `dsh-plugin` topic（另有 deepseek-harness/cordis/permission/approval/ai-safety）
- [x] 已在本 PR 开启 Allow edits from maintainers
- [x] 所有运行时依赖已声明（chokidar/yaml/tsdown/typescript 在 `dependencies`；官方 `@deepseek-ai/*` 在 `peerDependencies`）
- [x] 已按自检三步实测（Windows 无 `<(...)` 进程替换，等价改为「先 `dsh plugin add` 注册行，再 `--dump-config` 验证」）：

```
# 1. 安装并加载插件（本地 0.4.1 tarball，与 npm 发布产物同一构建）
dsh plugin --profile pr-verify add ./dsh-permission-rules-0.4.1.tgz   # Packages: +36, exit 0
# 2. 挂载级验证：插件行正常进入组合，无 FAILED
dsh --profile pr-verify --dump-config
# == dsh-permission-rules
# - id: permission-rules
#   name: dsh-permission-rules
# 3. 完整会话运行 dsh --profile pr-verify "hi"：本环境无 DEEPSEEK_API_KEY，
#    模型路由阶段无法完成（120s 超时退出）；插件加载阶段无报错。
```

- [x] 自检结果贴这里：加载级实测通过（见上，真实执行输出）；完整会话运行未执行成功（无 API key），故状态列如实填「待测」。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-permission-rules | https://github.com/PerryLink/dsh-permission-rules | Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则，在 tools/pre-execute 瀑布上匹配工具名/参数/工作区路径/agent 身份，带会话日志审计、干跑模式与热重载 |

## 备注

- 命名空间：当前使用自有命名空间 `dsh-permission-rules`，获得 dsh-external 维护权限后再迁移。
- 运行级证据：仓库自带 CI（3 OS × Node 22/24，139 测试）与 npm 发布（0.4.1），但未走本仓的 k8s 实测流程，故运行状态列如实填「待测」，未声称「运行级可用」。
