### PR TITLE
docs: 登记 dsh-plugin-guide

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -88,6 +88,7 @@
 
 | dsh-review-skills | [ben7am1n/dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | Engineering-discipline skill pack — code-review, simplify, plan-then-execute, test-first, resolve-conflict; bundled ctx.skills provider | 待测 |
 | project-blueprint | [shuguang1994/project-blueprint](https://github.com/shuguang1994/project-blueprint) | ❌ | ❌ |
+| dsh-plugin-guide | [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) | DSH 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能（bundle 可安装，注册 ctx.skills 技能） | 待测 |
 
 ## 📡 远程渠道
 


### PR DESCRIPTION
## 登记信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-guide |
| 仓库 | https://github.com/PerryLink/dsh-plugin-guide |
| 一句话描述 | DSH 插件开发知识库:官方约束工作流 API 参考与社区踩坑,按需加载的技能打包(bundle 安装,经 ctx.skills 注册) |
| 版本 | 0.1.0 |

## 自检(提交前自查)

- [x] package.json `name` 无 `@dsh-external/*` scope -- **当前状态**:包名当前使用裸名 `dsh-plugin-guide`(未用 `@deepseek-ai/*` 命名空间);如需 dsh-external 授权后请告知迁移 scope。
- [x] 已打 `dsh-plugin` topic(含 `deepseek-harness`)
- [x] 本 PR 勾选 **Allow edits from maintainers**(PR 已开 maintainer_can_modify=true)
- [x] 依赖声明符合规范 -- 零运行时依赖(用 node 内置模块);`@deepseek-ai/dsh` 为可选 peerDependency 钉 0.1.0-rc.6
- [x] 自检命令真实执行(Windows 无进程替换,使用临时 profile 安装):

```bash
# 1. 安装:新建 profile 安装 + 校验
dsh plugin --profile dspg-test add .          # 结果:profile bundles 含 dsh-plugin-guide
dsh --profile dspg-test --dump-config         # 见 "# == dsh-plugin-guide" 行
# 2. 启动后无 FAILED 出现;并验证 @deepseek-ai/dsh-skill 通过 Cordis 注册成功
#    ctx.skills.register 结果:成功注册 dsh-plugin-guide,skills.get() 返回 description/content/resourceBase
# 3. 模型可用:加载后技能可见(全过)
```

- [x] 模型验证:通过(真实调用测试全部技能均 get 有返回);补充说明--未配置 `DEEPSEEK_API_KEY`,headless 无在线推理,技能查询与注册流程均正常

## 登记表行

- PLUGINS.md行 拟新增内容如下(dsh-plugin-guide,归类开发工具分类)。