### PR TITLE
docs: 登记 dsh-image-gen

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -155,3 +155,4 @@
 | dsh-composer-history | [PerryLink/dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) | 终端风格作曲器输入历史：边缘优先方向键召回并精确还原草稿与光标、浏览器本地持久化历史、Ctrl+R 反向搜索、滑动上下文感知（压缩摘要加入召回与搜索）；dsh.bundle manifest 可安装；rc.6 headless --patch 加载实测通过 | 待测 |
 | dsh-output-styles | [PerryLink/dsh-output-styles](https://github.com/PerryLink/dsh-output-styles) | Claude Code outputStyles 兼容的运行时输出风格切换：/style 命令、按会话持久化（output_style 域）、systemPrompt 注入、六个内置风格、自定义 Markdown/JSON 风格库与热重载、Web 选择器；npm dsh-output-styles 0.3.2；rc.6 真实 bundle 安装 + profile 加载实测通过（详见 PR 自检） | 待测 |
 | dsh-auto-review | [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | 审批链上的第二模型 AI 自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，fail-closed 兜底，全量会话日志审计；Web 审查面板；npm 可装 | 待测 |
+| dsh-image-gen | [LeemanCheung/dsh-image-gen](https://github.com/LeemanCheung/dsh-image-gen) | GPT Image 2 生图工具：真实流式局部图与 Codex 风格显影动画，成图经 DSH 附件持久化并支持回放/预览/下载；20 项 keyless 测试，rc.6 Web profile 已加载验证 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-image-gen |
| 仓库 | https://github.com/LeemanCheung/dsh-image-gen |
| 一句话说明 | GPT Image 2 生图工具：真实流式局部图、Codex 风格显影卡片、DSH 附件回放与下载。 |
| 版本 | v0.1.0 |

## 自检清单

- [x] 包名 `dsh-image-gen` 为作者控制的非 scope 名称，未占用 `@deepseek-ai/*`，也未冒用 `@dsh-external/*`。
- [x] 仓库已打 `dsh-plugin` topic。
- [x] 已允许维护者编辑来自 fork 的 PR。
- [x] 所有运行时依赖均声明为 `peerDependencies`。
- [x] 根 `package.json` 声明 `dsh.bundle` 与 Web `dsh.client`，预构建 Host/Client 产物已提交。
- [x] 自检结果：`npm run check` 通过（20 项 keyless 测试、双端 typecheck、Host/Client build、built-artifact smoke、publint）；`npm audit --omit=dev` 为 0 漏洞；从公开 `v0.1.0` 标签安装到隔离 rc.6 profile 成功，`--dump-config` 出现 `image-gen`，组装 Web profile 的页面与 `/plugins/dsh-image-gen/client.js` 均返回 200。由于环境没有 `OPENAI_API_KEY`，未执行真实付费生图请求。

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-image-gen | [LeemanCheung/dsh-image-gen](https://github.com/LeemanCheung/dsh-image-gen) | GPT Image 2 生图工具：真实流式局部图与 Codex 风格显影动画，成图经 DSH 附件持久化并支持回放/预览/下载；20 项 keyless 测试，rc.6 Web profile 已加载验证 | 待测 |

## 备注

`v0.1.0` 目前支持从文本生成新图；参考图编辑等待安全的 DSH 附件选择与外部上传授权后再开放。