### PR TITLE
docs: 登记 dsh-lsp-actions

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -155,3 +155,17 @@
 | dsh-output-styles | [PerryLink/dsh-output-styles](https://github.com/PerryLink/dsh-output-styles) | Claude Code outputStyles 兼容的运行时输出风格切换：/style 命令、按会话持久化（output_style 域）、systemPrompt 注入、六个内置风格、自定义 Markdown/JSON 风格库与热重载、Web 选择器；npm dsh-output-styles 0.3.2；rc.6 真实 bundle 安装 + profile 加载实测通过（详见 PR 自检） | 待测 |
 | dsh-auto-review | [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | 审批链上的第二模型 AI 自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，fail-closed 兜底，全量会话日志审计；Web 审查面板；npm 可装 | 待测 |
 | dsh-image-gen | [LeemanCheung/dsh-image-gen](https://github.com/LeemanCheung/dsh-image-gen) | GPT Image 2 生图工具：真实流式局部图与 Codex 风格显影动画，成图经 DSH 附件持久化并支持回放/预览/下载；20 项 keyless 测试，rc.6 Web profile 已加载验证 | 待测 |
+| dsh-lsp-actions | [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) | LSP 动作面：诊断/格式化/补全/代码动作/符号/签名提示/inlay 提示/重命名 8 工具，官方 seam 优先 + 内置 stdio 客户端兜底；写入走 write-intent 与沙箱策略，其余只读；241 测试 + 真实 tsls e2e + CI 矩阵全绿，npm dsh-lsp-actions | 待测 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2255 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1528 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1049 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 916 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 385 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 290 | AgentTeams plugin for DeepSeek Harness |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 171 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 151 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 115 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 111 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [modsearch](https://github.com/liustack/modsearch) | 99 | The web plugin for DeepSeek Harness, and the search bri… |


### PR DESCRIPTION
## 插件信息

- 插件名：dsh-lsp-actions
- 仓库：https://github.com/PerryLink/dsh-lsp-actions
- 一句话说明：LSP 动作面——诊断/格式化/补全/代码动作/符号/签名提示/inlay 提示/重命名 8 工具，由真实语言服务器驱动
- 版本：0.2.0（npm 已发布）

## 最低收录条件自检（对照 README「给插件开发者 → 最低收录条件」）

- [x] 仓库公开，带 `dsh-plugin` topic
- [x] 根目录 `package.json`，`name: dsh-lsp-actions`
- [x] 提供 `main`（lib/index.js）与 `exports`
- [x] README 含功能说明、安装/卸载（`dsh plugin --profile <name> add / remove`）与最小配置示例
- [x] 运行时依赖显式声明（官方 `@deepseek-ai/*` 均为 peerDependencies ≥ 0.1.0-rc.6）
- [x] 声明支持的 DSH 版本与验证日期（README「Host version support」：0.1.0-rc.6，last verified 2026-08-15）
- [x] Apache-2.0 许可证；不含密钥/个人信息

命名空间：使用自有命名空间 `dsh-lsp-actions`（npm 已发布），符合 README「包名应使用你有权控制的命名空间」的要求；未使用 `@dsh-external/*`。

## 运行级状态

表格状态列填「待测」：本仓库运行级为 k8s 集群实测口径（一插件一 pod），本人未跑该流程，如实填「待测」。

## 本地自检（真实执行，Windows 环境）

任务给出的自检命令在 Windows 无进程替换，改用等价临时 patch 文件写法（headless-patch.yml）：

```yaml
- insert:
    - id: lsp-actions
      name: dsh-lsp-actions
```

1. `dsh --profile headless --patch headless-patch.yml "hi"` 首次失败，原因是 `--patch` 只插入补丁行、不会安装包：`Cannot find package 'dsh-lsp-actions' imported from C:\Users\...\.dsh\profiles\headless\`（ERR_MODULE_NOT_FOUND）。
2. 改为先真实安装：`dsh plugin --profile headless add D:\...\dsh-lsp-actions` → 安装成功（`+ dsh-lsp-actions link:...`，exit 0）。
3. 随后 `dsh --profile headless "hi"` 因该 profile 内预装的另一个插件未激活而失败：`dsh-checkpoint-rewind: pending (waiting for service: storageDomain)` —— 失败列表**不含 dsh-lsp-actions**，即它在 headless 组合中激活成功。
4. 干净 profile 复核：`dsh plugin --profile lsp-actions-check add D:\...\dsh-lsp-actions` → 安装成功（exit 0）；`dsh --profile lsp-actions-check "hi"` 启动后无任务输出（本机未配置模型凭据，进程等待，已终止）。

本环境无法完成完整「最小任务」执行，如实报告：安装与插件树加载已验证，端到端任务未完成（缺模型凭据）。

仓库测试套件为可复现的独立证据：241 个单元/集成测试 + 真实 typescript-language-server e2e（诊断/格式化/补全/符号/重命名）全绿，覆盖率门禁与 CI 矩阵（Node 22/24 × ubuntu/windows/macos）全绿。


## 改动内容（PLUGINS.md 追加的行）

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-lsp-actions | [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) | LSP 动作面：诊断/格式化/补全/代码动作/符号/签名提示/inlay 提示/重命名 8 工具，官方 seam 优先 + 内置 stdio 客户端兜底；写入走 write-intent 与沙箱策略，其余只读；241 测试 + 真实 tsls e2e + CI 矩阵全绿，npm dsh-lsp-actions | 待测 |

## 备注

- PR 模板的自检清单第一项要求 @dsh-external/* scope；本插件当前使用自有命名空间 dsh-lsp-actions（npm 已发布）。README「最低收录条件」明文允许有权控制的命名空间，且注明「只有获得 dsh-external 维护权限的项目才应使用 @dsh-external/*」——当前未获该权限，待获得 dsh-external 维护权限后再迁移。
- 本地自检为 Windows 环境真实执行（安装成功 + 插件树加载成功；完整最小任务因本机无模型凭据未完成，已在正文如实记录）。