### PR TITLE
docs: 登记 dsh-approve-for-me

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -78,6 +78,7 @@
 | dsh-side-chat | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问（按会话隔离，继承主会话模型/思考难度/权限），AI 回复可原文或摘要带回主会话，问题弹框选项可一键带入 | 待测 |
 | dsh-subagent-max | [aaravarr/dsh-subagent-max](https://github.com/aaravarr/dsh-subagent-max) | 子代理委派按次指定模型/提供商（host 侧 `subagent_with_model` 工具）+ 多面板实时流式子代理查看器（client 侧浮动面板 token 级流式输出、卡片网格、拖拽弹出、中英 i18n）；rc.6 headless 实测通过 | ✅ |
 | dsh-permission-rules | [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) | Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则，在 tools/pre-execute 瀑布上匹配工具名/参数/工作区路径/agent 身份，带会话日志审计、干跑模式与热重载；npm 已发布 | 待测 |
+| dsh-approve-for-me | [timeance/dsh-approve-for-me](https://github.com/timeance/dsh-approve-for-me) | DeepSeek Harness 沙箱扩权审批：Shell/PowerShell 字面命令前缀规则、固定高风险检查、可选无工具 LLM reviewer；成功仅授予一次 `allowed-once`，高危或不确定请求回原生人工审批，支持 Web/headless Profile | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

- 插件名：`dsh-approve-for-me`
- 仓库：https://github.com/timeance/dsh-approve-for-me
- 当前版本：`0.1.0-beta.2`
- 分类：`🔌 单插件`

## 一句话说明

面向 DeepSeek Harness 的规则门控沙箱扩权审批插件：支持 Shell/PowerShell 字面命令前缀规则、固定高危检查、可选的无工具 LLM 审核器、一次性 `allowed-once` 授权，以及 Web/headless Profile 下的原生人工审批回退。

## 兼容性与安全边界

- 已针对 DeepSeek Harness `0.1.0-rc.6` 完成验证。
- npm 包有意保持非 scope 名称 `dsh-approve-for-me`，不占用保留的 `@deepseek-ai/*` 命名空间。
- 高危或不确定请求会回到原生人工审批；本插件不宣称提供绝对安全边界。
- 运行级保留为“待测”，供市场维护者独立验证后决定。

## 维护者自测证据

- `pnpm check`：类型检查、8 个测试文件共 153 个测试，以及构建均通过。
- 隔离 Headless Profile：仅绑定 loopback 的 mock LLM 返回预设的 `pwsh Get-Location` 扩权请求；session 日志记录了 `approval/asked`、结果为 `allowed-once` 的 `approval/decided`、命令输出和退出码 `0`。
- 隔离 Web Profile：插件成功加载，`dsh web` 返回 HTTP `200`，页面包含插件 bundle 标记。

## 清单

- [x] 公开仓库，并已添加 `dsh-plugin` Topic
- [x] 根目录包含 `package.json`，运行时依赖已明确声明
- [x] README 包含概览、安装、配置、排错、开发、许可证和安全说明
- [x] 未包含密钥或第三方凭据
- [x] 已允许维护者编辑

