### PR TITLE
docs: 登记 dsh-plugin-marketplace 等 4 个插件

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -79,6 +79,10 @@
 | dsh-subagent-max | [aaravarr/dsh-subagent-max](https://github.com/aaravarr/dsh-subagent-max) | 子代理委派按次指定模型/提供商（host 侧 `subagent_with_model` 工具）+ 多面板实时流式子代理查看器（client 侧浮动面板 token 级流式输出、卡片网格、拖拽弹出、中英 i18n）；rc.6 headless 实测通过 | ✅ |
 | dsh-permission-rules | [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) | Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则，在 tools/pre-execute 瀑布上匹配工具名/参数/工作区路径/agent 身份，带会话日志审计、干跑模式与热重载；npm 已发布 | 待测 |
 | dsh-approve-for-me | [timeance/dsh-approve-for-me](https://github.com/timeance/dsh-approve-for-me) | DeepSeek Harness 沙箱扩权审批：Shell/PowerShell 字面命令前缀规则、固定高风险检查、可选无工具 LLM reviewer；成功仅授予一次 `allowed-once`，高危或不确定请求回原生人工审批，支持 Web/headless Profile | 待测 |
+| dsh-plugin-marketplace | [Scorp1o117/dsh-plugin-marketplace](https://github.com/Scorp1o117/dsh-plugin-marketplace) | Web UI 内置插件市场：设置页直接浏览 github.com/topics/dsh-plugin，搜索/按 Star 排序/README 摘要；settings 通道一键安装并自动挂载 cordis.patch.yml；AI 解释；npm 已发布 | 待测 |
+| dsh-soul-md | [Scorp1o117/dsh-soul-md](https://github.com/Scorp1o117/dsh-soul-md) | soul.md 风格人设 + 长期记忆：设置页输入人设卡名称和内容即可，文件由插件自动管理；按工作区指定人设、聊天框可给会话单独切人设；AI 可自行演化人设与记忆（soul_read/soul_update/memory_*）；npm 已发布 | 待测 |
+| dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 | 待测 |
+| dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
<!--
  插件登记 PR 模板 —— 按此格式提交，合并后立即进入目录。
  目标文件：PLUGINS.md（表格追加一行即可）。
-->

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-marketplace、dsh-soul-md、dsh-tdai-memory、dsh-tool-vision（共 4 个，一次登记） |
| 仓库 | https://github.com/Scorp1o117/dsh-plugin-marketplace · https://github.com/Scorp1o117/dsh-soul-md · https://github.com/Scorp1o117/dsh-tdai-memory · https://github.com/Scorp1o117/dsh-tool-vision |
| 一句话说明 | 插件市场 / 人设卡+长期记忆 / TDAI 记忆移植 / 外置视觉模型（见下方表格行） |
| 版本 | dsh-plugin-marketplace v0.2.3 · dsh-soul-md v0.5.3 · dsh-tdai-memory v0.2.7 · dsh-tool-vision v0.3.8（均已发布 npm） |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）——四个包均为无 scope 的独立包名（`dsh-*`），未占用保留命名空间
- [x] 仓库已打 `dsh-plugin` topic（四个仓库均已打，雷达自动表中已收录三个）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（本 PR 已通过 API 开启 `maintainer_can_modify`）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies` 完整）
- [x] 已按自检三步实测通过：

```bash
# 1. 四个插件均在 DSH 0.1.0-rc.6（Windows 11 · Node 22）web profile 挂载运行
# 2. dsh-tool-vision 已被雷达标 ✅ 运行级可用；dsh-soul-md / dsh-plugin-marketplace 本地实测
#    （人设切换、记忆工具、一键安装流程）通过
# 3. 依赖均声明于 package.json（schemastery / dsh-settings / dsh-tools / dsh-home-paths / react）
```

- [x] 自检结果：dsh-soul-md v0.5.3 与 dsh-plugin-marketplace v0.2.3 已在真实环境（web profile）加载并验证核心功能（人设解析切换、memory 工具、安装通道）；tdai-memory 与 tool-vision 在雷达自动表中已有记录（tool-vision ✅）

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-plugin-marketplace | [Scorp1o117/dsh-plugin-marketplace](https://github.com/Scorp1o117/dsh-plugin-marketplace) | Web UI 内置插件市场：设置页直接浏览 github.com/topics/dsh-plugin，搜索/按 Star 排序/README 摘要；settings 通道一键安装并自动挂载 cordis.patch.yml；AI 解释；npm 已发布 |
| dsh-soul-md | [Scorp1o117/dsh-soul-md](https://github.com/Scorp1o117/dsh-soul-md) | soul.md 风格人设 + 长期记忆：设置页输入人设卡名称和内容即可，文件由插件自动管理；按工作区指定人设、聊天框可给会话单独切人设；AI 可自行演化人设与记忆（soul_read/soul_update/memory_*）；npm 已发布 |
| dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 |
| dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 |

## 备注

- dsh-plugin-marketplace 未出现在当前雷达快照中（自动表中仅收录了其他作者的 marketplace 同名插件），故本次一并登记
- dsh-tool-vision 已在雷达标 ✅，其余三个标「待测」，欢迎雷达 k8s 集群复核


---

**Update**: also registering dsh-enhancement-suite (Scorp1o117) under 🧰 插件集 — the official installer/entry point for the four plugins (npm: dsh-enhancement-suite v0.1.0).