### PR TITLE
docs: 登记 dsh-compressor

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -85,6 +85,7 @@
 | dsh-soul-md | [Scorp1o117/dsh-soul-md](https://github.com/Scorp1o117/dsh-soul-md) | soul.md 风格人设 + 长期记忆：设置页输入人设卡名称和内容即可，文件由插件自动管理；按工作区指定人设、聊天框可给会话单独切人设；AI 可自行演化人设与记忆（soul_read/soul_update/memory_*）；npm 已发布 | 待测 |
 | dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 | 待测 |
 | dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
+| dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-compressor |
| 仓库 | https://github.com/lifeodyssey/dsh-compressor |
| 一句话说明 | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 |
| 版本 | 0.1.0 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 是 `dsh-compressor`（npm 已发布；未占用 `@deepseek-ai/*`。没用 `@dsh-external`）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明
- [x] 已按自检三步实测通过：

自检结果：已 `dsh plugin --profile headless add dsh-compressor`（写入 bundles，不再 `--patch insert`）。用 `--patch` 把 `agent-default-model` 改成 `opencode-go` / `deepseek-v4-flash` 后跑 `hi`：加载无报错，退出码 0，模型正常回复。pnpm 提示 missing peer `@deepseek-ai/dsh-tools`，profile 已有该包，运行时未出错。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-compressor | https://github.com/lifeodyssey/dsh-compressor | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 |
