### PR TITLE
docs: 登记 dsh-result-only-view

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -177,3 +177,4 @@
 | cc-dsh-notifier | [baobaolaodie/cc-dsh-notifier](https://github.com/baobaolaodie/cc-dsh-notifier) | Windows 桌面通知:Claude Code hooks 与 dsh web/tui 双 surface 事件(权限请求/提问/工具报错/等待输入)→ 原生 Toast + 点击跳转;聚焦感知静默、多会话、tarball 零手工安装;Windows 10/11 专用 | 待测 |
 | dsh-openviking | [Rxiain/dsh-openviking](https://github.com/Rxiain/dsh-openviking) | OpenViking 检索、资源管理、自动召回与会话记忆：memsearch/memfind 等 10 个工具、已索引仓库上下文注入、自动召回注入、会话同步+自动提交 | ✅ |
 | dsh-session-hotkeys | [YEYEYEYESHIFU/dsh-session-hotkeys](https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys) | Web UI 会话快捷键：Alt+1-9 顺序切换、固定槽位三态、Alt+↑↓ 循环切换、高亮导航模式、归档/重命名/新建会话、可改键面板（键盘导航 + 内置诊断），Windows/macOS 双预设无冲突，npm 已发布 | 待测 |
+| dsh-result-only-view | [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-result-only-view |
| 仓库 | https://github.com/YEYEYEYESHIFU/dsh-result-only-view |
| **分类** | 🔌 单插件 |
| 一句话说明 | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可展开回看；中英双语，常规设置可配置。 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间（unscoped `dsh-result-only-view`，未占用 `@deepseek-ai/*` 保留命名空间；与目录中多数无 scope 条目一致）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已开启 Allow edits from maintainers（fork 层面已允许，PR 页面侧亦已勾选）
- [x] 所有运行时依赖已声明（零 dependencies；`react` 与注入的官方客户端包已声明为 `peerDependencies`）
- [x] 已按自检三步实测通过：

```bash
# 1-3: 本机 Windows 环境未用 bash 进程替换 <(...)；
# 以更强的实机证据替代：插件已在真实 web profile 安装并生产运行（v1.5.x），
# npm run verify（文件完整性/语法/bundle id/apply 冒烟）通过，
# GitHub Actions CI（Node 22, verify）全绿。
```

- [x] 自检结果贴这里：生产环境 web profile 实机运行通过（开关/实时行/痕迹行/设置面板均验证）；`npm run verify` 冒烟通过；CI 绿。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-result-only-view | https://github.com/YEYEYEYESHIFU/dsh-result-only-view | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 |

## 备注

- npm 包：`dsh-result-only-view@1.5.x`（latest）；许可证 MIT。
- 运行级状态先标「待测」，等雷达 k8s 实测出结论后如有问题欢迎指正。
- 已知边界：隐藏依赖产品 DOM 稳定属性（data-tool 等），产品升级更换属性时优雅降级（仅停止隐藏），不影响页面稳定性；README 兼容性章节已声明。
