### PR TITLE
docs: 登记 dsh-session-hotkeys

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -176,3 +176,4 @@
 | dsh-plugin | [plur-ai/dsh-plugin](https://github.com/plur-ai/dsh-plugin) | PLUR 持久记忆：engram 在每次 assembly 渲染进 system prompt（section 的 text 为函数），而非藏在工具调用后——记忆块被替换而非追加，上下文长度不随会话增长（实测 60 轮恒定）；全本地 BM25 + BGE 混合检索（RRF 融合，零 API 调用）、可编辑的纯 YAML 存储、按工作区划分 scope、/plur 与 /plur-memory 命令 | ✅ |
 | cc-dsh-notifier | [baobaolaodie/cc-dsh-notifier](https://github.com/baobaolaodie/cc-dsh-notifier) | Windows 桌面通知:Claude Code hooks 与 dsh web/tui 双 surface 事件(权限请求/提问/工具报错/等待输入)→ 原生 Toast + 点击跳转;聚焦感知静默、多会话、tarball 零手工安装;Windows 10/11 专用 | 待测 |
 | dsh-openviking | [Rxiain/dsh-openviking](https://github.com/Rxiain/dsh-openviking) | OpenViking 检索、资源管理、自动召回与会话记忆：memsearch/memfind 等 10 个工具、已索引仓库上下文注入、自动召回注入、会话同步+自动提交 | ✅ |
+| dsh-session-hotkeys | [YEYEYEYESHIFU/dsh-session-hotkeys](https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys) | Web UI 会话快捷键：Alt+1-9 顺序切换、固定槽位三态、Alt+↑↓ 循环切换、高亮导航模式、归档/重命名/新建会话、可改键面板（键盘导航 + 内置诊断），Windows/macOS 双预设无冲突，npm 已发布 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-session-hotkeys |
| 仓库 | https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys |
| **分类** | 🔌 Web UI 增强 |
| 一句话说明 | Web UI 会话快捷键：Alt+1-9 顺序切换、固定槽位三态、Alt+↑↓ 循环切换、高亮导航模式、归档/重命名/新建会话、可改键面板（键盘导航 + 内置诊断）；Windows/macOS 零冲突双预设；npm 已发布（1.5.1）。 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用无 scope 的 `dsh-session-hotkeys`（未占用 `@deepseek-ai/*` 或 `@dsh-external/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] Allow edits from maintainers（用户 fork 默认开启）
- [x] 所有运行时依赖已声明（peerDependencies：react + 注入的 @deepseek-ai/dsh-client-runtime / dsh-client-ui-layout / dsh-client-ui-sidebar；无其它运行时依赖）
- [x] 自检结果：本插件为纯浏览器端 client bundle（`dsh.client.platform: web`，注入 runtime/layout/sidebar，宿主半部为 no-op），headless 无 UI 路径，改用等效验证：

- `node --check lib/client.js` 通过；
- `npm run verify`（verify-self-contained：包结构 / bundle 可解析 / 无外部依赖）通过；
- 实际 Web profile 挂载运行中（dsh web @0.1.0-rc.6，2026-08-16），快捷键、面板、导航模式均已人工验证可用。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-session-hotkeys | https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys | Web UI 会话快捷键：Alt+1-9 顺序切换、固定槽位三态、Alt+↑↓ 循环切换、高亮导航模式、归档/重命名/新建会话、可改键面板（键盘导航 + 内置诊断），Windows/macOS 双预设无冲突，npm 已发布 |

## 备注

- 运行级状态先标「待测」，等待雷达 k8s 实测。
- 已知限制（已写入 README）：会话顺序与搜索框定位依赖 DSH Web DOM 类名（带模糊回退）。
