### PR TITLE
docs: 登记 dsh-result-only-view

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -86,6 +86,7 @@
 | dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 | 待测 |
 | dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
 | dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
+| dsh-result-only-view | [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-result-only-view |
| 仓库 | https://github.com/YEYEYEYESHIFU/dsh-result-only-view |
| **分类** | 🔌 Web UI 增强（taxonomy v2） |
| 一句话说明 | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 |

## 自检清单

- [x] package.json `name` 未被 `@deepseek-ai/*` 保留命名空间占用
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 fork Settings → General 开启 Allow edits and access to secrets by maintainers
- [x] 所有运行时依赖已声明（peerDependencies：react、@deepseek-ai/dsh-client-*）
- [x] 自检：`npm run verify` 通过；DSH Web 配置实测通过

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-result-only-view | [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) | 见上方一句话说明 |

## 备注

同时已向 DSH Hub Workshop（hub.omdsh.dev）提交 [Submission] Issue；纯浏览器端 Cordis client bundle。
