### PR TITLE
docs: 登记 dsh-skill-pack-security

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -9,6 +9,8 @@
 ## 🔌 单插件
 
 | 插件 | 仓库 | 说明 | 运行级 |
+|---|---|---|---|
+| dsh-office | [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) | 办公室工作区/会话仪表盘：悬浮 6 列精灵面板，可视化工作区、会话、token 用量与子代理（web bundle） | ✅ |
 | deepseek-heartflow | [yun520-1/deepseek-heartflow](https://github.com/yun520-1/deepseek-heartflow) | 心虫（AGI 第1层辨别门禁）：47 维纯规则文本判别 heartflow_check 工具 + tools/post-execute 自动输出监督（block 拦截 / rewrite 提醒），引擎缺失 fail-closed；dsh.bundle manifest 可安装 | ✅ |
 | dsh-repo-context | [qing3a/dsh-repo-context](https://github.com/qing3a/dsh-repo-context) | 把 git 状态与仓库规范动态注入 system prompt（section/context/variable，官方 system-prompt 缝隙插件）；dsh-plugin-verify 0.1.2 实测 7/7 waterfall + 工具真实执行（R3 isError:false） | ✅ |
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
@@ -38,8 +40,7 @@
 | dsh-oauth-mcp-client | [springbrand-lab/dsh-oauth-mcp-client](https://github.com/springbrand-lab/dsh-oauth-mcp-client) | 为 DSH 连接支持 OAuth 2.1 的 Streamable HTTP MCP 服务 | 待测 |
 | dsh-balance | [TwotwoPiggy/dsh-balance](https://github.com/TwotwoPiggy/dsh-balance) | 在 DSH Web 聊天框底部实时估算对话 Token 消耗并显示您的 DeepSeek 账户余额 | ✅ |
 | ds-api-usage | [Sev7een/ds-api-usage](https://github.com/Sev7een/ds-api-usage) | 在设置页展示 DeepSeek API 余额与最近 24 小时用量，包括估算消费、Token、请求次数和按小时时间线 | ✅ |
-| falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | 待测 |
-| billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | ✅ |
+| falsify-dsh | [shi275773124/falsify-dsh](https://github.com/shi275773124/falsify-dsh) | 公开 Falsify CLI 适配器：裁决收据（lint / review --json / gate）。不是第二意见工作流；selftest ≠ claim-bearing | ✅ || billion-context-dsh | [Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：compress/decompress/search_context/acp_status 工具，模型决定何时压缩，移植自 billion-context-pi | ✅ |
 | dsh-web-search-firecrawl | [yangzhe1003/dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方：内置 web_search 工具接入 Firecrawl 搜索 API（npm @yangzhe1003/dsh-web-search-firecrawl） | ❌ |
 | dsh-test-runner | [suimi8/dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化测试运行工具 test_run：自动探测 vitest/jest/pytest/node:test，执行并解析失败摘要，避免模型阅读整段原始测试输出 | 待测 |
 | dsh-agent-message | [GengDaPeng/dsh-agent-message](https://github.com/GengDaPeng/dsh-agent-message) | 跨会话 Agent 通信：让运行在同一 DeepSeek Harness 进程里的不同 Agent 会话互相收发消息 | 待测 |
@@ -65,7 +66,8 @@
 | dsh-visual-plugin | [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) | DSH 视觉桥接插件：主模型无视觉时把用户图片转发到任意 OpenAI 兼容视觉模型（DeepSeek (Vision) 包装适配器 + Web 右侧面板配置/测试/历史），自动拦截描述并支持按问题定向提示词 | ✅ |
 | dsh-vision-proxy | [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | DeepSeek 大脑 + 自动识图：GUI 附加的每张图片自动经 OpenAI 兼容 VLM 转译成文字后交给纯文本 DeepSeek——有 key 自动走快速通道（默认 qwen3.7-flash，支持百炼/智谱/OpenRouter 等任意兼容端点），无 key 自动探测本地 Ollama（零配置） | ✅ |
 | DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |
-| dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审；原生实现于 DSH 扩展点（技能/工具策略/审批 seam/会话日志） | 待测 |
+| dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审 + 交付报告与逐维度核对（verify 工作流）；/doublecheck 会话命令、en/zh 双语、npm 已发布 0.6.0 | 待测 |
+| dsh-git-plugin | [IT-coder-Yy/dsh-git-plugin](https://github.com/IT-coder-Yy/dsh-git-plugin) | 面向 DSH Web 的可视化 Git 工作台：查看仓库状态、Diff、分支、提交历史与贮藏，点击执行常用 Git 操作，并安全运行 AI 生成的分步骤 Git 提议；npm `dsh-easygit-plugin` 0.2.1，DSH 0.1.0-rc.6 实测 | 待测 |
 
 | dsh-mcp-adapter | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | 一个 mcp 代理工具：按需 search/describe/call，不把每个 MCP schema 塞进上下文；Web `/mcp` 菜单可添加/连接/授权 | ✅ |
 | logicprobe | [AmethystLuna/logicprobe](https://github.com/AmethystLuna/logicprobe) | 设计文档与重构计划声明核查：claim 枚举 + 代码库事实核对 + 逻辑原语验证（7 结构 + 7 对抗探针），dsh 原生 bundle 注入核查纪律门 | ✅ |
@@ -74,32 +76,50 @@
 
 | dsh-hdc-bridge | [1na-ko/dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 鸿蒙设备桥：hdc 设备闭环（截图/装包/日志/崩溃/UI 自动化）+ 官方优先 API 知识层（SDK .d.ts + 离线 Tier-1 随包）+ DevEco CLI 构建/签名/lint；无头 DSH 实例真实 E2E 已验证 | ✅ |
 | deepseek-skin-studio | [JueMing2049/deepseek-skin-studio](https://github.com/JueMing2049/deepseek-skin-studio) | DSH 换肤工作室：一张图一套皮肤，三通道注入（书签/CDP/原生插件）+ 可视化工坊 + 13 套内置主题 + DSH-SKIN-SPEC 导出 | 待测 |
-| dsh-agent-preset-recommender | [LeemanCheung/dsh-agent-preset-recommender](https://github.com/LeemanCheung/dsh-agent-preset-recommender) | 隐私安全本地扫描 Codex、Claude Code、WorkBuddy、CodeBuddy 的会话/workflow 元数据，持久化聚合证据并推荐 DSH 内置 Agent preset；不保留正文、不联网、不自动修改 preset | 待测 |
+| dsh-agent-preset-recommender | [LeemanCheung/dsh-agent-preset-recommender](https://github.com/LeemanCheung/dsh-agent-preset-recommender) | 有界、隐私安全的本地扫描器：汇总 Codex、Claude Code、WorkBuddy、CodeBuddy 元数据，原子保存密钥化聚合证据，并确定性推荐 DSH 内置 preset 与可选能力；不保留正文、不联网、不修改 preset | 待测 |
 | dsh-side-chat | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | DSH Web 侧边聊天：选中对话片段在右侧面板的侧边聊天提问（按会话隔离，继承主会话模型/思考难度/权限），AI 回复可原文或摘要带回主会话，问题弹框选项可一键带入 | 待测 |
 | dsh-subagent-max | [aaravarr/dsh-subagent-max](https://github.com/aaravarr/dsh-subagent-max) | 子代理委派按次指定模型/提供商（host 侧 `subagent_with_model` 工具）+ 多面板实时流式子代理查看器（client 侧浮动面板 token 级流式输出、卡片网格、拖拽弹出、中英 i18n）；rc.6 headless 实测通过 | ✅ |
+| dsh-permission-rules | [PerryLink/dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) | Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则，在 tools/pre-execute 瀑布上匹配工具名/参数/工作区路径/agent 身份，带会话日志审计、干跑模式与热重载；npm 已发布 | 待测 |
+| dsh-approve-for-me | [timeance/dsh-approve-for-me](https://github.com/timeance/dsh-approve-for-me) | DeepSeek Harness 沙箱扩权审批：Shell/PowerShell 字面命令前缀规则、固定高风险检查、可选无工具 LLM reviewer；成功仅授予一次 `allowed-once`，高危或不确定请求回原生人工审批，支持 Web/headless Profile | 待测 |
+| dsh-plugin-marketplace | [Scorp1o117/dsh-plugin-marketplace](https://github.com/Scorp1o117/dsh-plugin-marketplace) | Web UI 内置插件市场：设置页直接浏览 github.com/topics/dsh-plugin，搜索/按 Star 排序/README 摘要；settings 通道一键安装并自动挂载 cordis.patch.yml；AI 解释；npm 已发布 | 待测 |
+| dsh-soul-md | [Scorp1o117/dsh-soul-md](https://github.com/Scorp1o117/dsh-soul-md) | soul.md 风格人设 + 长期记忆：设置页输入人设卡名称和内容即可，文件由插件自动管理；按工作区指定人设、聊天框可给会话单独切人设；AI 可自行演化人设与记忆（soul_read/soul_update/memory_*）；npm 已发布 | 待测 |
+| dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 | 待测 |
+| dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
+| dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
 ## 🧰 插件集
 
+| 插件 | 仓库 | 说明 | 运行级 |
+|---|---|---|---|
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |
 | dsh-subagent-cwd | [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) | dsh-subagent-tools 加按次 cwd（子代理工作目录），附两处进程内 provider 补丁；rc.6 前台/后台 cwd 实测通过 | ✅ |
 | dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体更新提醒：npm latest 高于本地版本时侧边栏左下角红点+Modal（复制更新命令/忽略此版本/稍后再说），官方 ui-primitives 渲染，无更新零 UI；零构建、25 单测、rc.5/rc.6 加载与端点 E2E 实测 | 待测 |
-| （暂无手工登记；打标自动收录） | | |
 
 ## 🎓 技能
 
+| 插件 | 仓库 | 说明 | 运行级 |
+|---|---|---|---|
 | dsh-review-skills | [ben7am1n/dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) | Engineering-discipline skill pack — code-review, simplify, plan-then-execute, test-first, resolve-conflict; bundled ctx.skills provider | 待测 |
 | project-blueprint | [shuguang1994/project-blueprint](https://github.com/shuguang1994/project-blueprint) | ❌ | ❌ |
+| dsh-plugin-guide | [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) | DSH 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能（bundle 可安装，注册 ctx.skills 技能） | 待测 |
+| dsh-chinese-traditional-wisdom-skill | [dhicoc/dsh-chinese-traditional-wisdom-skill](https://github.com/dhicoc/dsh-chinese-traditional-wisdom-skill) | 中华传统智慧（玄枢）AI Agent 技能包：八字/紫微/六爻/梅花/奇门/风水/五运六气/体质全融合，本地确定性引擎 + 可视化 Dashboard；dsh.bundle manifest 可安装 | ✅ |
+| dsh-skill-pack-security | [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本；`dsh plugin add @perrylink/dsh-skill-pack-security-provider` 一键挂载 | 待测 |
 
 ## 📡 远程渠道
 
+| 插件 | 仓库 | 说明 | 运行级 |
+|---|---|---|---|
 | dsh-telegram | [ben7am1n/dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram runtime adapter — chat with dsh agents from Telegram; per-chat sessions, followup bridging, committed-text streaming, allowlist auth, zero runtime deps | 待测 |
 | dsh-webhook-bridge | [ben7am1n/dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | ✅ | ✅ |
 | dsh-lark-bot | [PlutoKeating/dsh-lark-bot](https://github.com/PlutoKeating/dsh-lark-bot) | dsh-lark-bot：把 DeepSeek Harness (dsh) 桥接进飞书/Lark 的 bot — 标准 dsh profile bundle（`dsh plugin add` 一行安装），桥接引擎在 dsh 进程内运行；流式卡片、git worktree 项目隔离、scope 并行任务、多角色 Agent、会话归档、lark_notify 跨会话通知、安全网守护（dsh 下线后经飞书 /safemode 仅核心自愈）（0.8.0） | ✅ |
+| dsh-lark-link | [amlyczz/dsh-lark-link](https://github.com/amlyczz/dsh-lark-link) | High-reliability Feishu/Lark bridge — QR one-click auth, CardKit streaming, zero-loss persistent outbox (at-least-once), per-conversation DSH sessions, self-healing connection, media in/out, reusable DSH Web GUI | ✅ |
 | dsh-wechat-bridge | [gtaifu/dsh-wechat-bridge](https://github.com/gtaifu/dsh-wechat-bridge) | WeChat bridge via official Tencent iLink bot API — QR-code login, one friend = one persistent agent session, zero runtime deps, no OpenClaw | ❌ |
 | dsh-onebot | [mario841859784/dsh-onebot](https://github.com/mario841859784/dsh-onebot) | QQ 渠道插件（OneBot 11 / NapCat）：反向/正向 WS、dm/群聊访问策略与 @ 门控、入站图片/语音/视频/文件解析 + whisper 转写、t2i 文字图卡片、斜杠命令、loop 合并转发+撤回（99 测试全绿，真实 QQ 链路实测） | 待测 |
 | dsh-session-hub | [Asaiuta/dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) | 多服务器 DSH 会话聚合与原生操控：网关+官方 UI 桥，一屏合并多个远程 dsh web 的会话，支持历史/prompt/取消/重命名/fork/模型选择/审批问答，并导入本机其他工具的历史会话 | 待测 |
 
 ## 🛠 基础设施
 
+| 插件 | 仓库 | 说明 | 运行级 |
+|---|---|---|---|
 | dsh-work | [vibeinging/dsh-work](https://github.com/vibeinging/dsh-work) | 以 dsh 为骨、codex 为皮的桌面 app | 待测 |
 | deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 | ✅ |
 | dsh-remote-sandbox | [weijiafu14/dsh-remote-sandbox](https://github.com/weijiafu14/dsh-remote-sandbox) | 生产级远程执行世界：E2B 沙箱内纯 JS sidecar，fs/subprocess 单次往返、进程输出有界、心跳保活、崩溃透明恢复（resume/recreate）、tar 工作区同步；修复官方 e2b POC 两处 host 假设。43 项测试（含 6 项真机 E2E）全绿 | 已测 |
@@ -126,12 +146,13 @@
 | dsh-plugin-installer | [zhang66633/dsh-plugin-installer](https://github.com/zhang66633/dsh-plugin-installer) | 插件商店 + 安装助手：Web GUI「插件商店」页签 + 内置安装技能（npm 直装 / GitHub clone 注册，18 个已知坑配方） | 待测 |
 | dsh-malong-bridge | [wulun811/LiuHe](https://github.com/wulun811/LiuHe) | 六合工具集 DSH bundle：44 个 MCP 代码操作工具 + 动态 workspace 注入；npm 安装 @jieai/dsh-malong-bridge | 待测 |
 | dsh-oai-oauth | [werifu/dsh-oai-oauth](https://github.com/werifu/dsh-oai-oauth) | OpenAI ChatGPT OAuth LLM 适配器：让 dsh 直接使用 ChatGPT 订阅（非 API Key）接入模型 | 待测 |
-| dsh-lark-link | [amlyczz/dsh-lark-link](https://github.com/amlyczz/dsh-lark-link) | High-reliability Feishu/Lark bridge — QR one-click auth, CardKit streaming, zero-loss persistent outbox (at-least-once), per-conversation DSH sessions, self-healing connection, media in/out, reusable DSH Web GUI | 待测 |
-| dsh-whale-animation | [LeemanCheung/dsh-whale-animation](https://github.com/LeemanCheung/dsh-whale-animation) | DSH Web 回合状态旁的闭环鲸鱼潜行动画：资源内嵌、运行时离线，并为 `prefers-reduced-motion` 用户提供静态 PNG 回退 | 待测 |
-| dsh-token-usage | [LeemanCheung/dsh-token-usage](https://github.com/LeemanCheung/dsh-token-usage) | 持久化 Token 用量记录与设置页仪表盘：按模型、会话和日期聚合，展示 52 周热力图、缓存命中率及完整输入输出 bucket，不保存提示词或回复正文 | 待测 |
-| dsh-task-dag | [LeemanCheung/dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) | DSH Web 持久实时任务 DAG：统一展示会话、子代理与 workflow 阶段，支持状态联动和节点导航，不维护并行数据库或轮询 Host | 待测 |
+| dsh-whale-animation | [LeemanCheung/dsh-whale-animation](https://github.com/LeemanCheung/dsh-whale-animation) | DSH Web 回合状态旁的 60 帧随主题适配的单色鲸鱼深潜动画：传播式水面、无缝闭环、资源内嵌、`prefers-reduced-motion` 静态 PNG 回退，停止时完整清理 | 待测 |
+| dsh-token-usage | [LeemanCheung/dsh-token-usage](https://github.com/LeemanCheung/dsh-token-usage) | 本地优先的四 bucket Token 可观测性：持久会话/provider/model/日期仪表盘、趋势、预算与异常信号、公开费率估算、安全聚合导出，以及显式触发的用量/会话轨迹分析 | 待测 |
+| dsh-task-dag | [LeemanCheung/dsh-task-dag](https://github.com/LeemanCheung/dsh-task-dag) | 由投影驱动的会话子代理与持久工作流实时 DAG：状态与节点导航、深层链路确定性布局、适应/平移画布，以及当前会话内节点拖动重排；无并行数据库或 Host 轮询 | 待测 |
+| dsh-qq2007-skin | [LeemanCheung/dsh-qq2007-skin](https://github.com/LeemanCheung/dsh-qq2007-skin) | DSH Web GUI 的 QQ 2007 风格皮肤：72 个原生主题 token、作用域三栏窗框、原创离线素材与像素伙伴、可选合成发送提示音、响应式/无障碍回退和可恢复设置开关 | 待测 |
 | dsh-sql | [STARDUSTLC666/dsh-sql](https://github.com/STARDUSTLC666/dsh-sql) | 工程师级数据库插件：sql_list/query/exec/schema 四工具，SQLite/MySQL/PostgreSQL 三引擎、多连接、只读白名单、写操作审批门、行数钳制 | 待测 |
 | dsh-feishucard | [cmfok/dsh-feishucard](https://github.com/cmfok/dsh-feishucard) | DSH ↔ 飞书桥（自研非 fork）：官方 SDK 长连接（无需公网）+ 流式回复卡片（过程话语内联/工具折叠面板/状态符号/限流退避熔断兜底），每聊天独立会话 + live 复用保上下文，配置独立 ~/.dsh-feishucard；npm dsh-feishucard v0.1.0，冒烟 18 项 + 实机链路实测通过 | ✅ |
+| dsh-trajectory-reader | [flyingtimes/dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) | 轨迹解读标签页：按用户轮次解读助手行为（需求/思路/执行/结果），规则引擎 + 可选 LLM 叙述，文件/命令/错误一目了然，用户消息原样保留；dsh.bundle.patch 一键安装 | ✅ |
 | dsh-remotion | [STARDUSTLC666/dsh-remotion](https://github.com/STARDUSTLC666/dsh-remotion) | 视频创作技能插件：注册 Remotion 官方移植技能（React 编程式视频，动画/音频/字幕/3D/图表/字体 + 38 个规则文件），安装即用 | 待测 |
 | dsh-hyperframes | [STARDUSTLC666/dsh-hyperframes](https://github.com/STARDUSTLC666/dsh-hyperframes) | 视频创作技能插件：注册 HyperFrames by HeyGen 官方移植技能五件套（HTML 写视频 / hyperframes CLI / 注册表 / 网址转视频 / GSAP 参考），安装即用 | 待测 |
 | dsh-voice | [STARDUSTLC666/dsh-voice](https://github.com/STARDUSTLC666/dsh-voice) | 语音双件套：voice_tts（edge-tts 协议免费微软神经语音，Sec-MS-GEC 本地 DRM 生成）/ voice_stt（OpenAI 兼容 ASR）/ voice_list，WS 压缩 + 可选代理隧道 | 待测 |
@@ -140,3 +161,12 @@
 | dsh-theme-plugin | [BeiZi6/dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) | DSH Web GUI 主题工作室：5 套内置预设（codex-warm / nord / solarized / graphite / stock）+ 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），经官方 theme overrideTokens 即时热切换、localStorage 持久化，纯官方接缝无补丁文件 | 待测 |
 | dsh-opencodego-usage | [BeiZi6/dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) | OpenCodeGo 剩余额度监视器：输入框右下角呼吸灯（按剩余额度绿/黄/红）+ 液态玻璃面板（滚动/周/月三窗口用量与重置时间），每 30 秒自动刷新，Key 自动读取 DSH 凭据（opencode-go 提供商）也可手动覆盖 | 待测 |
 | dsh-usage-dashboard | [Cassius0924/dsh-usage-dashboard](https://github.com/Cassius0924/dsh-usage-dashboard) | DeepSeek 额度与用量仪表盘：悬浮额度窗 + 「额度」tab，余额可用天数、今日/本月消耗环比、模型/会话成本排行、缓存节省、2026-08-17 峰谷定价前后账单对比，估算算法与单价公开在 src/pricing.ts | 待测 |
+| dsh-checkpoint-rewind | [PerryLink/dsh-checkpoint-rewind](https://github.com/PerryLink/dsh-checkpoint-rewind) | Claude Code /rewind 等价能力：每次变更型工具执行前捕获 git 优先工作区快照（stash create / commit-tree 未引用对象，copy 兜底），轮次边界 fork 会话，一条 /rewind 命令恢复文件并回退会话（三段式事务 + 保护检查点 + preview 只读预览 + 增量字节配额）；npm 可装，160 单测 + Win/Linux CI 全绿 | 待测 |
+| dsh-composer-history | [PerryLink/dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) | 终端风格作曲器输入历史：边缘优先方向键召回并精确还原草稿与光标、浏览器本地持久化历史、Ctrl+R 反向搜索、滑动上下文感知（压缩摘要加入召回与搜索）；dsh.bundle manifest 可安装；rc.6 headless --patch 加载实测通过 | 待测 |
+| dsh-output-styles | [PerryLink/dsh-output-styles](https://github.com/PerryLink/dsh-output-styles) | Claude Code outputStyles 兼容的运行时输出风格切换：/style 命令、按会话持久化（output_style 域）、systemPrompt 注入、六个内置风格、自定义 Markdown/JSON 风格库与热重载、Web 选择器；npm dsh-output-styles 0.3.2；rc.6 真实 bundle 安装 + profile 加载实测通过（详见 PR 自检） | 待测 |
+| dsh-auto-review | [PerryLink/dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) | 审批链上的第二模型 AI 自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，fail-closed 兜底，全量会话日志审计；Web 审查面板；npm 可装 | 待测 |
+| dsh-image-gen | [LeemanCheung/dsh-image-gen](https://github.com/LeemanCheung/dsh-image-gen) | GPT Image 2 `image_gen`：默认复用 Codex 订阅 OAuth，也可显式使用 API Key；显影卡片、最多 3 张 API 实时局部图、持久附件回放/灯箱/下载、纯文本模型输出和受限的凭据安全请求 | 待测 |
+| dsh-lsp-actions | [PerryLink/dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) | LSP 动作面：诊断/格式化/补全/代码动作/符号/签名提示/inlay 提示/重命名 8 工具，官方 seam 优先 + 内置 stdio 客户端兜底；写入走 write-intent 与沙箱策略，其余只读；241 测试 + 真实 tsls e2e + CI 矩阵全绿，npm dsh-lsp-actions | 待测 |
+| dsh-agfs | [openAGFS/dsh-agfs](https://github.com/openAGFS/dsh-agfs) | 文件浏览器 Web 插件（npm `@open-agfs/dsh-agfs`，`dsh plugin add` 一行安装）：宿主 webserver 同进程托管 React 前端 + REST API + `/dsh-agfs` 命令 + `browse_files`/`read_file` 模型工具；一键AI分析（右键建工作区并唤醒新会话，与手动创建一致的 agent preset 工具集）、本地打开（系统文件管理器）、三种显示尺寸、Win10 文件管理器主题（Segoe MDL2 Assets 官方图标）；109 单测 + 真实 Loader/HTTP 组合测试全绿，rc.6 web profile 实测通过（一键分析真实运行 55 次工具调用 0 错误） | ✅ |
+| dsh-open-eyes | [Hyp6666/dsh-open-eyes](https://github.com/Hyp6666/dsh-open-eyes) | 让用户选择的多模态模型成为 DeepSeek 的眼睛：显式纯文本路由下桥接 WebUI 粘贴/拖入图片，并提供 vision_analyze；原生支持 OpenAI Responses、Chat Completions 与 Anthropic Messages，Credential Reference + workspace 边界；125 单测、Node 22/24 CI 与真实 tarball 临时 profile 安装/卸载通过 | 待测 |
+| dsh-plugin | [plur-ai/dsh-plugin](https://github.com/plur-ai/dsh-plugin) | PLUR 持久记忆：engram 在每次 assembly 渲染进 system prompt（section 的 text 为函数），而非藏在工具调用后——记忆块被替换而非追加，上下文长度不随会话增长（实测 60 轮恒定）；全本地 BM25 + BGE 混合检索（RRF 融合，零 API 调用）、可编辑的纯 YAML 存储、按工作区划分 scope、/plur 与 /plur-memory 命令 | ✅ |

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 20:36（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2387 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1649 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1116 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 981 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2417 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1680 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1130 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1008 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 401 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 385 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 403 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 389 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 300 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 198 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 186 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 181 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 158 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 148 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 303 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 199 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 193 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 183 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 151 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 107 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 108 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 103 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:21（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2295 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1566 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2316 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1585 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1316 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1066 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1073 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 937 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 950 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 390 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 395 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 376 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 292 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 193 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 178 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 173 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 153 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 125 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 295 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 194 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 177 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 155 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 144 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 129 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 97 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 101 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,15 +89,15 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:00（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:28（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2666 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1872 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2671 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1876 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1243 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1236 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1245 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1241 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
@@ -109,9 +109,9 @@ graph TB
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 158 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 138 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 117 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 160 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 139 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 118 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:42（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:17（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2694 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1898 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1255 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2698 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1902 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1259 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1258 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 413 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
-| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
+| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:43（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:17（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2516 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1767 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1178 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1103 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2549 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1796 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1196 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1131 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 414 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 416 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 320 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 205 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 204 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 186 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 323 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 207 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 187 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 155 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 143 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 120 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 144 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 122 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 109 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 16:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 16:59（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2225 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1498 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1314 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1030 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2255 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1528 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1049 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 893 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 916 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 383 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 371 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 385 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 326 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 288 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 290 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 191 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 176 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 164 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 149 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 141 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 113 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 110 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [modsearch](https://github.com/liustack/modsearch) | 98 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 93 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 171 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 151 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 115 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 111 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [modsearch](https://github.com/liustack/modsearch) | 99 | The web plugin for DeepSeek Harness, and the search bri… |
+| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 94 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,27 +89,27 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:52（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:19（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2675 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1879 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2682 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1883 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1249 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1243 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1252 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1247 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 410 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 332 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 430 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 411 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 333 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 219 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 170 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 160 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 161 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 140 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 120 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,15 +89,15 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:39（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2702 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1905 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2705 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1907 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1260 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1259 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1261 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1261 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
@@ -110,7 +110,7 @@ graph TB
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 144 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 145 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:20（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:43（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2505 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1749 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2516 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1767 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1167 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1083 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1178 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1103 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 587 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 412 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 396 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 414 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 317 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 320 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 205 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 200 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 185 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 204 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 186 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 154 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 142 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 113 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 155 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 143 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 120 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:19（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:43（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2682 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1883 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2685 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1888 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
 | 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1252 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1247 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1248 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 430 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 432 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 411 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 333 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 219 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 170 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 161 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 140 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 120 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 141 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:55（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:18（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2338 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1610 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1086 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2362 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1624 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1097 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 962 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 583 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 398 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 966 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 400 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 380 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 296 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 298 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 196 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 182 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 183 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 157 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 146 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 131 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 104 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 105 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 09:21（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2705 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1907 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2730 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1920 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1261 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1261 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1274 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1269 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 414 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
-| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 437 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 416 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 340 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 194 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 145 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
-| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 171 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 163 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 149 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 146 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 126 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 10:46（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 11:45（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2775 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1963 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1324 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1305 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1293 | DSH 官方公众号收录的 TUI 补位插件：Claude Code 风，鲸鱼顶栏/实时状态/流式思考/双击 E… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2825 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1984 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1332 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1324 | Local-first AI token usage & cost tracker for 31 coding… |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1310 | DSH 官方公众号收录的 TUI 补位插件：Claude Code 风，鲸鱼顶栏/实时状态/流式思考/双击 E… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 593 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 440 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 417 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 344 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 446 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 418 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 345 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 225 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 228 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 217 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 202 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 15 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 196 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 174 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 175 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [whale-girl](https://github.com/vlln/whale-girl) | 173 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 18 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 167 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 155 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 168 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 166 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 126 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,22 +89,22 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:42（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2691 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1896 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2694 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1898 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1255 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
@@ -112,7 +112,7 @@ graph TB
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
-| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:47（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:20（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2472 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1726 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2505 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1749 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1152 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1059 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1167 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1083 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 586 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 409 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 394 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 587 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 412 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 396 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 309 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 203 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 198 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 184 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 153 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 137 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 317 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 205 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 200 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 185 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 154 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 142 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 111 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 113 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:33（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2277 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1555 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1060 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2295 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1566 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1316 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1066 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 927 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 937 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 389 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 390 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 326 | Open-source alternative to Claude Cowork — a local-firs… |
+| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 292 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 193 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 177 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 178 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
 | 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 173 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 153 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 121 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 125 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 94 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 97 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:39（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2362 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1624 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1097 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 966 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2376 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1636 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1107 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 974 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 400 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 380 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 382 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 298 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 196 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 183 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 157 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 146 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 131 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 197 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 186 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 181 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 158 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 148 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 105 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 106 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:40（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2570 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1803 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1204 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1142 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2584 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1813 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1211 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1159 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 417 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 418 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 324 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 187 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 164 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 209 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 188 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 165 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 145 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 123 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 147 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 125 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 110 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 112 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:25（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2602 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1825 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2622 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1837 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1221 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1175 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1231 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1198 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 420 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 422 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 325 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 212 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 210 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 188 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 167 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 214 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 159 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 153 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 133 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 156 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 112 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 114 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:21（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:55（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2316 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1585 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1316 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1073 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2338 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1610 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1086 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 950 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 395 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 376 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 962 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 583 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 398 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 380 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 295 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 194 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 177 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 155 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 144 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 129 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 101 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 296 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 196 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 182 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 157 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 146 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 131 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 104 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 20:36（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:16（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2417 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1680 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2458 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1704 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1130 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1008 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1144 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1035 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 403 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 389 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 586 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 405 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 391 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 303 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 199 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 193 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 183 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 305 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 202 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 194 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 184 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 151 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 152 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 135 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 108 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 20 | [modsearch](https://github.com/liustack/modsearch) | 103 | The web plugin for DeepSeek Harness, and the search bri… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 110 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,19 +89,19 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:17（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:39（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2698 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1902 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2702 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1905 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1259 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1258 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1260 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1259 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 413 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 414 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
@@ -110,7 +110,7 @@ graph TB
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 144 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,26 +89,26 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:19（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:40（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2634 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1850 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1234 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1207 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2639 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1858 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1321 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1236 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1213 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 422 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 424 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 405 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 215 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 216 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 163 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 165 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 157 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 02:25（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:00（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2655 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1869 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1321 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1238 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1224 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2666 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1872 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1243 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1236 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 427 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 406 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 331 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 407 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 332 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 192 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 167 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 158 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 137 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 138 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 117 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:19（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2622 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1837 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2634 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1850 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1231 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1198 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1234 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1207 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 422 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 214 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 215 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 159 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 156 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 163 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 157 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 114 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,28 +89,28 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:40（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:18（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2690 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1894 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2691 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1896 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1253 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 335 | AgentTeams plugin for DeepSeek Harness |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 142 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:17（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:40（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2549 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1796 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2570 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1803 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1196 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1131 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1204 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1142 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 416 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 417 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 323 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 207 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 324 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 187 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 164 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 144 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 122 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 145 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 123 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 109 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 110 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,28 +89,28 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:25（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2584 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1813 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1211 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1159 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2602 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1825 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1221 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1175 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 418 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 324 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 209 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 420 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 325 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 212 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 210 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 188 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 165 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 147 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 125 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 167 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 159 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 153 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 133 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 112 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,12 +89,12 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:40（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2689 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1891 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2690 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1894 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
 | 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1253 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
@@ -102,15 +102,15 @@ graph TB
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 334 | AgentTeams plugin for DeepSeek Harness |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 335 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 170 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 161 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 141 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 142 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 16:59（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:33（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2255 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1528 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2277 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1555 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1049 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1060 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 916 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 927 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 385 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 389 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 326 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 290 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 191 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 176 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 171 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 151 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 292 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 193 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 177 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 173 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 153 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 115 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 111 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [modsearch](https://github.com/liustack/modsearch) | 99 | The web plugin for DeepSeek Harness, and the search bri… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 121 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 | 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 94 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,30 +89,30 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:39（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2376 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1636 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2387 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1649 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1107 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 974 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1116 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 981 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 400 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 382 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 401 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 385 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 298 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 197 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 300 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 198 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 186 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 181 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 158 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 148 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 106 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 107 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [modsearch](https://github.com/liustack/modsearch) | 103 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,20 +89,20 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:43（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:18（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2685 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1888 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2689 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1891 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1252 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1248 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1253 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 432 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 411 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 333 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 334 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:16（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:47（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2458 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1704 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2472 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1726 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1144 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1035 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1152 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1059 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 586 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 405 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 391 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 409 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 394 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 305 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 202 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 194 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 309 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 203 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 198 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 184 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 152 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 135 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 153 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 137 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 110 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 111 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,29 +89,29 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 09:21（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 10:46（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2730 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1920 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1274 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1269 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2775 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1963 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1324 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1305 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1293 | DSH 官方公众号收录的 TUI 补位插件：Claude Code 风，鲸鱼顶栏/实时状态/流式思考/双击 E… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 437 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 416 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 340 | AgentTeams plugin for DeepSeek Harness |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 593 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 440 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 417 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 344 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 194 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 171 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 163 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 149 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 146 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 225 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 14 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 202 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 15 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 196 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 174 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [whale-girl](https://github.com/vlln/whale-girl) | 173 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 18 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 167 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 155 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 126 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,19 +89,19 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:28（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:52（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2671 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1876 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2675 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1879 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1245 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1241 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1249 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1243 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 407 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 410 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 332 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
@@ -110,8 +110,8 @@ graph TB
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 160 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 139 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 118 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 140 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 120 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.en-US.md
+++ b/README.en-US.md
@@ -89,28 +89,28 @@ graph TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:40（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 02:25（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2639 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1858 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2655 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1869 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1321 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1236 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1213 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1238 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1224 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 424 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 405 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 216 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 427 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 406 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 331 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 165 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 157 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 192 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 167 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 158 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 137 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:20（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:43（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2505 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1749 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2516 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1767 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1167 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1083 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1178 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1103 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 587 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 412 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 396 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 414 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 317 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 320 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 205 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 200 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 185 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 204 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 186 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 154 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 142 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 113 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 155 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 143 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 120 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 20:36（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2387 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1649 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1116 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 981 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2417 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1680 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1130 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1008 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 401 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 385 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 403 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 389 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 300 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 198 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 186 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 181 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 158 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 148 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 303 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 199 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 193 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 183 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 151 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 107 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 108 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 103 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:28（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:52（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2671 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1876 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2675 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1879 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1245 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1241 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1249 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1243 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 407 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 410 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 332 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
@@ -99,8 +99,8 @@ flowchart TB
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 160 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 139 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 118 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 140 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 120 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 02:25（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:00（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2655 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1869 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1321 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1238 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1224 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2666 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1872 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1243 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1236 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 427 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 406 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 331 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 407 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 332 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 192 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 167 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 158 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 137 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 138 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 117 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,27 +78,27 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:52（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:19（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2675 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1879 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2682 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1883 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1249 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1243 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1252 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1247 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 410 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 332 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 430 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 411 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 333 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 219 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 170 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 160 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 161 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 140 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 120 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 09:21（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2705 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1907 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2730 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1920 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1261 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1261 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1274 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1269 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 414 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
-| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 437 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 416 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 340 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 194 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 145 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
-| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 171 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 163 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 149 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 146 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 126 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 16:59（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:33（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2255 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1528 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2277 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1555 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1049 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1060 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 916 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 927 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 385 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 389 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 326 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 290 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 191 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 176 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 171 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 151 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 292 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 193 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 177 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 173 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 153 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 115 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 111 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [modsearch](https://github.com/liustack/modsearch) | 99 | The web plugin for DeepSeek Harness, and the search bri… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 121 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 | 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 94 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:42（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:17（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2694 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1898 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1255 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2698 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1902 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1259 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1258 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 413 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
-| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
+| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:55（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:18（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2338 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1610 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1086 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2362 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1624 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1097 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 962 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 583 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 398 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 966 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 400 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 380 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 296 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 298 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 196 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 182 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 183 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 157 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 146 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 131 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 104 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 105 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:39（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2376 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1636 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2387 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1649 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1107 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 974 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1116 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 981 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 400 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 382 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 401 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 385 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 298 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 197 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 300 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 198 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 186 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 181 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 158 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 148 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 106 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 107 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [modsearch](https://github.com/liustack/modsearch) | 103 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:39（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2702 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1905 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2705 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1907 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1260 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1259 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1261 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1261 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
@@ -99,7 +99,7 @@ flowchart TB
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 144 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 145 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 09:21（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 10:46（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2730 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1920 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1274 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1269 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2775 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1963 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1324 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1305 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1293 | DSH 官方公众号收录的 TUI 补位插件：Claude Code 风，鲸鱼顶栏/实时状态/流式思考/双击 E… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 437 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 416 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 340 | AgentTeams plugin for DeepSeek Harness |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 593 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 440 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 417 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 344 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 194 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 171 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 163 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 149 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 146 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 225 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 14 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 202 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 15 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 196 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 174 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [whale-girl](https://github.com/vlln/whale-girl) | 173 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 18 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 167 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 155 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 126 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:16（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:47（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2458 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1704 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2472 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1726 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1144 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1035 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1152 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1059 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 586 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 405 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 391 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 409 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 394 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 305 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 202 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 194 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 309 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 203 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 198 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 184 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 152 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 135 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 153 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 137 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 110 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 111 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:19（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2622 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1837 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2634 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1850 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1231 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1198 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1234 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1207 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 422 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 214 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 215 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 159 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 156 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 163 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 157 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 114 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:47（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:20（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2472 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1726 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2505 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1749 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1152 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1059 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1167 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1083 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 586 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 409 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 394 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 587 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 412 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 396 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 309 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 203 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 198 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 184 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 153 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 137 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 317 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 205 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 200 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 185 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 154 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 142 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 111 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 113 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:17（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 07:39（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2698 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1902 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2702 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1905 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1323 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1259 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1258 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1260 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1259 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 413 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 414 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
@@ -99,7 +99,7 @@ flowchart TB
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 172 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 144 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 122 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 22:43（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:17（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2516 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1767 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1178 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1103 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2549 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1796 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1196 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1131 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 414 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 416 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 320 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 205 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 204 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 186 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 323 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 207 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 187 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 155 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 143 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 120 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 144 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 122 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 109 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:40（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2570 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1803 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1204 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1142 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2584 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1813 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1211 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1159 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 417 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 418 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 324 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 187 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 164 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 209 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 188 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 165 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 145 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 123 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 147 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 125 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 110 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 112 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:33（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2277 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1555 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1060 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2295 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1566 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1316 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1066 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 927 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 937 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 389 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 390 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 326 | Open-source alternative to Claude Cowork — a local-firs… |
+| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 292 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 193 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 177 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 178 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
 | 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 173 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 153 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 121 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 125 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 94 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 97 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:21（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:55（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2316 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1585 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1316 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1073 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2338 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1610 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1086 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 950 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 395 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 376 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 962 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 583 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 398 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 380 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 295 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 194 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 177 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 155 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 144 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 129 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 101 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 296 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 196 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 182 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 157 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 146 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 131 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 104 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 10:46（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 11:45（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2775 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1963 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1324 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1305 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
-| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1293 | DSH 官方公众号收录的 TUI 补位插件：Claude Code 风，鲸鱼顶栏/实时状态/流式思考/双击 E… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2825 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1984 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1332 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1324 | Local-first AI token usage & cost tracker for 31 coding… |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1310 | DSH 官方公众号收录的 TUI 补位插件：Claude Code 风，鲸鱼顶栏/实时状态/流式思考/双击 E… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 973 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 593 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 440 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 417 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 344 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 446 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 418 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 345 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 225 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 228 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 217 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 202 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 15 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 196 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 174 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 175 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [whale-girl](https://github.com/vlln/whale-girl) | 173 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 18 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 167 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 155 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 168 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 166 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 126 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,22 +78,22 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:42（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2691 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1896 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2694 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1898 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1255 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 591 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 221 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
@@ -101,7 +101,7 @@ flowchart TB
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
-| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 116 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 19:39（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2362 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1624 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1097 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 966 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2376 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1636 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1107 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 974 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 400 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 380 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 382 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 298 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 196 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 183 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 157 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 146 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 131 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 197 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 186 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 181 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 158 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 148 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 114 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 105 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 106 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 20 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,28 +78,28 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:25（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2584 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1813 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1211 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1159 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2602 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1825 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1221 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1175 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 418 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 324 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 209 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 420 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 325 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 212 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 210 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 188 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 165 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 147 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 125 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 167 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 159 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 153 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 133 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 112 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 17:56（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 18:21（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2295 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1566 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2316 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1585 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1316 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1066 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1073 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 937 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 950 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 390 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 395 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 376 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 292 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 193 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 178 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 173 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 153 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 125 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 295 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 194 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 179 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 177 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 155 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 144 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 129 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 112 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 | 19 | [modsearch](https://github.com/liustack/modsearch) | 101 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 97 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 101 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,26 +78,26 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:19（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:40（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2634 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1850 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1234 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1207 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2639 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1858 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1321 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1236 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1213 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 422 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 424 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 405 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 215 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 216 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 163 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 165 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 157 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |

--- a/README.md
+++ b/README.md
@@ -78,28 +78,28 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:40（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 06:18（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2690 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1894 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2691 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1896 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1253 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1254 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 335 | AgentTeams plugin for DeepSeek Harness |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 336 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 16 | [whale-girl](https://github.com/vlln/whale-girl) | 170 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 142 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 143 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.md
+++ b/README.md
@@ -78,20 +78,20 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:43（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:18（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2685 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1888 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2689 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1891 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1252 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1248 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1253 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 432 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 411 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 333 | AgentTeams plugin for DeepSeek Harness |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 334 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:25（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 00:56（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2602 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1825 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2622 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1837 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1320 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1221 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1175 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1231 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1198 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 420 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 422 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 404 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 325 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 212 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 210 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 188 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 167 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 214 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 159 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 153 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 133 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 156 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 112 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 114 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 16:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 16:59（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2225 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1498 | The first vision plugin for DeepSeek Harness, and the v… |
-| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1314 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1030 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2255 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1528 | The first vision plugin for DeepSeek Harness, and the v… |
+| 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1315 | Local-first AI token usage & cost tracker for 31 coding… |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1049 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 893 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 6 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 916 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 581 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 383 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 371 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 385 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 372 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 326 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 288 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 290 | AgentTeams plugin for DeepSeek Harness |
 | 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 191 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 13 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 176 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验，支持分… |
-| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 164 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 149 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 141 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 113 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 110 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [modsearch](https://github.com/liustack/modsearch) | 98 | The web plugin for DeepSeek Harness, and the search bri… |
-| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 93 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 14 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 171 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 151 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 143 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 115 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 111 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
+| 19 | [modsearch](https://github.com/liustack/modsearch) | 99 | The web plugin for DeepSeek Harness, and the search bri… |
+| 20 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 94 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:17（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 23:40（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2549 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1796 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2570 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1803 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1318 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1196 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1131 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1204 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1142 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 416 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 417 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 400 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 323 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 207 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 324 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 208 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 208 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 187 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 162 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 164 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 156 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 144 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 122 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 145 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 123 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 109 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 20 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 110 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 
 <!-- AUTO:featured:END -->
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:00（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 03:28（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2666 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1872 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2671 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1876 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1243 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1236 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1245 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1241 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 429 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
@@ -98,9 +98,9 @@ flowchart TB
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 169 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 158 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 138 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 117 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 160 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 139 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 118 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,29 +78,29 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:19（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 04:43（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2682 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1883 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2685 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1888 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
 | 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1252 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1247 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1248 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 430 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 432 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 411 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 333 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 219 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
 | 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 170 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
 | 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 161 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 140 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 120 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 141 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 
 <!-- AUTO:featured:END -->

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:18（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 05:40（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2689 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1891 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2690 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1894 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1322 | Local-first AI token usage & cost tracker for 31 coding… |
 | 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1253 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
 | 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1253 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
@@ -91,15 +91,15 @@ flowchart TB
 | 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
 | 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 433 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
 | 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 412 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 334 | AgentTeams plugin for DeepSeek Harness |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 335 | AgentTeams plugin for DeepSeek Harness |
 | 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
 | 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 220 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 211 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
 | 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 193 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 170 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 15 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 171 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
 | 16 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 161 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 141 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 162 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 142 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 121 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.md
+++ b/README.md
@@ -78,28 +78,28 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 01:40（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-16 02:25（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2639 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1858 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2655 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1869 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1321 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1236 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1213 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1238 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1224 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 588 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 424 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 405 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
-| 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 327 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 216 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 590 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 427 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 406 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 10 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 331 | AgentTeams plugin for DeepSeek Harness |
+| 11 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 329 | Open-source alternative to Claude Cowork — a local-firs… |
+| 12 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 218 | Codex-style @file mentions for DeepSeek Harness: search… |
 | 13 | [Bigfish](https://github.com/turtle2209/Bigfish) | 212 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 189 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
-| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 168 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 165 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 157 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
-| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 135 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 192 | 一套 DSH runtime，Desktop、Web 与 TUI 三种开发体验。 |
+| 15 | [whale-girl](https://github.com/vlln/whale-girl) | 169 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。 |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 167 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 158 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 18 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 137 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
 | 19 | [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 115 | 在 DSH 对话中生成交互式可视化｜Render model-generated interactive ca… |
 | 20 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
 

--- a/README.md
+++ b/README.md
@@ -78,30 +78,30 @@ flowchart TB
 
 <!-- AUTO:featured:START -->
 
-> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 20:36（UTC+8）。
+> 按 GitHub star 数排序，每 20 分钟自动刷新。数据截至 2026-08-15 21:16（UTC+8）。
 
 | # | 插件 | ⭐ | 说明 |
 |---|---|---|---|
-| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2417 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
-| 2 | [modlens](https://github.com/liustack/modlens) | 1680 | The first vision plugin for DeepSeek Harness, and the v… |
+| 1 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | 2458 | Plugin and skin collection for DeepSeek Harness (DSH) W… |
+| 2 | [modlens](https://github.com/liustack/modlens) | 1704 | The first vision plugin for DeepSeek Harness, and the v… |
 | 3 | [TokenTracker](https://github.com/xiufengsun/TokenTracker) | 1319 | Local-first AI token usage & cost tracker for 31 coding… |
-| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1130 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
-| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1008 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
+| 4 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | 1144 | 解决DSH 官方尚无终端 TUI 痛点的补位之作，献给偏爱cli的各位极客：Claude Code 风格全屏交… |
+| 5 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 1035 | 一个侧边栏的完整工作台，支持三方拓展注册新侧边栏页面。内置文件渲染编辑/终端/Git/子代理 |
 | 6 | [PicGo-Core](https://github.com/PicGo/PicGo-Core) | 972 | :zap:The ultimate image uploading engine. Both CLI & AP… |
-| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 584 | Open-source CMA-compatible agent runtime for any model,… |
-| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 403 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
-| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 389 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
+| 7 | [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | 586 | Open-source CMA-compatible agent runtime for any model,… |
+| 8 | [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 405 | 让纯文本模型更好地做视觉任务的DeepSeek Harness插件：带意图的图片问答、长截图 OCR、UI 还… |
+| 9 | [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 391 | 把 DSH 变成 2005 年门户网站｜Parody ads, fake games, and popups … |
 | 10 | [Abu-Cowork](https://github.com/PM-Shawn/Abu-Cowork) | 328 | Open-source alternative to Claude Cowork — a local-firs… |
-| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 303 | AgentTeams plugin for DeepSeek Harness |
-| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 199 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
-| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 193 | Codex-style @file mentions for DeepSeek Harness: search… |
-| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 183 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
+| 11 | [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | 305 | AgentTeams plugin for DeepSeek Harness |
+| 12 | [Bigfish](https://github.com/turtle2209/Bigfish) | 202 | Bigfish —— DeepSeek Harness 的第三方桌面端，内置 Node 运行时，双击即用，附带… |
+| 13 | [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | 194 | Codex-style @file mentions for DeepSeek Harness: search… |
+| 14 | [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 184 | 一站式 DeepSeek Harness 社区发行版：TUI、桌面端与 Web UI 三种形态统一体验。 |
 | 15 | [whale-girl](https://github.com/vlln/whale-girl) | 159 | DSH Web GUI 桌面宠物插件（QQ 宠物形态）：右下角悬浮、可拖拽/投喂/玩耍的积累型伙伴。官方 re… |
-| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 151 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
-| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 133 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
+| 16 | [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | 152 | dsh-tianshu-tui — DeepSeek Harness terminal UI +harness… |
+| 17 | [dsh-browser](https://github.com/Lum1104/dsh-browser) | 135 | dsh plugin: Chrome sidebar extension that lets DSH oper… |
 | 18 | [deepseek-harness-desktop-app](https://github.com/vibeinging/deepseek-harness-desktop-app) | 115 | DeepSeek Harness Desktop App: a local AI desktop worksp… |
-| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 108 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
-| 20 | [modsearch](https://github.com/liustack/modsearch) | 103 | The web plugin for DeepSeek Harness, and the search bri… |
+| 19 | [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 110 | Eyes for text-only DeepSeek Harness agents: built-in fr… |
+| 20 | [modsearch](https://github.com/liustack/modsearch) | 104 | The web plugin for DeepSeek Harness, and the search bri… |
 
 <!-- AUTO:featured:END -->
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-skill-pack-security |
| 仓库 | https://github.com/PerryLink/dsh-skill-pack-security |
| **分类** | 🎓 技能包（taxonomy v2 规则 1：`skill / 技能` 关键词命中；本地无 python3，预归类器未执行，按 CATALOGING.md 规则人工判定） |
| 一句话说明 | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本，npm provider 包一键挂载 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有可控命名空间 `@perrylink/*`（README 明文：仅有 `dsh-external` 维护权限的项目才应使用 `@dsh-external/*`；未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies`：`@deepseek-ai/cordis` ^4.0.1、`@deepseek-ai/dsh-skill-filesystem` 0.1.0-rc.6、`@deepseek-ai/schemastery` ^3.18.1）
- [x] 已按自检三步实测通过：

```bash
# Windows 无进程替换，按等价临时 patch 文件写法执行（--patch 接受文件路径）
dsh --profile headless --patch <selfcheck-patch.yml> "hi"
```

- [x] 自检结果贴这里：真实执行两次。① 全新 DSH_HOME 干净 profile：插件树加载通过（`skill-pack-security` 条目激活，boot 激活断言无失败），回合因新 HOME 无模型凭据报 `MISSING_CREDENTIAL`，停在模型调用前（环境限制，非插件问题）。② 真实 DSH_HOME + `--patch` overlay（临时禁用本地 profile 中两个与本插件无关、无法激活的既有插件 `checkpoint-rewind`/`lsp-actions`）：完整回合完成，exit=0，模型真实回复。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-skill-pack-security | [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本；`dsh plugin add @perrylink/dsh-skill-pack-security-provider` 一键挂载 |

## 备注

- 运行级状态按实际填「待测」：未经过本仓库 k8s 实测流程；本地 headless 加载级与完整回合已验证（见自检结果）。
- 本地 headless profile 中 `dsh-checkpoint-rewind` 因等待 `storageDomain` 服务无法激活（与本插件无关），自检经 overlay 临时禁用后通过，未改动 profile 文件。
- 获得 `dsh-external` 维护权限后可迁移命名空间，当前按 README 明文使用自有 `@perrylink/*` scope。