### PR TITLE
docs: 登记 dsh-skill-pack-security

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -102,6 +102,7 @@
 | project-blueprint | [shuguang1994/project-blueprint](https://github.com/shuguang1994/project-blueprint) | ❌ | ❌ |
 | dsh-plugin-guide | [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) | DSH 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能（bundle 可安装，注册 ctx.skills 技能） | 待测 |
 | dsh-chinese-traditional-wisdom-skill | [dhicoc/dsh-chinese-traditional-wisdom-skill](https://github.com/dhicoc/dsh-chinese-traditional-wisdom-skill) | 中华传统智慧（玄枢）AI Agent 技能包：八字/紫微/六爻/梅花/奇门/风水/五运六气/体质全融合，本地确定性引擎 + 可视化 Dashboard；dsh.bundle manifest 可安装 | ✅ |
+| dsh-skill-pack-security | [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本；`dsh plugin add @perrylink/dsh-skill-pack-security-provider` 一键挂载 | 待测 |
 
 ## 📡 远程渠道
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-skill-pack-security |
| 仓库 | https://github.com/PerryLink/dsh-skill-pack-security |
| **分类** | 🎓 技能包（taxonomy v2 规则 1：`skill / 技能` 关键词命中；本地无 python3，预归类器未执行，按 CATALOGING.md 规则人工判定） |
| 一句话说明 | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本，npm provider 包一键挂载 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有可控命名空间 `@perrylink/*`（README 明文：仅有 `dsh-external` 维护权限的项目才应使用 `@dsh-external/*`；未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies`：`@deepseek-ai/cordis` ^4.0.1、`@deepseek-ai/dsh-skill-filesystem` 0.1.0-rc.6、`@deepseek-ai/schemastery` ^3.18.1）
- [x] 已按自检三步实测通过：

```bash
# Windows 无进程替换，按等价临时 patch 文件写法执行（--patch 接受文件路径）
dsh --profile headless --patch <selfcheck-patch.yml> "hi"
```

- [x] 自检结果贴这里：真实执行两次。① 全新 DSH_HOME 干净 profile：插件树加载通过（`skill-pack-security` 条目激活，boot 激活断言无失败），回合因新 HOME 无模型凭据报 `MISSING_CREDENTIAL`，停在模型调用前（环境限制，非插件问题）。② 真实 DSH_HOME + `--patch` overlay（临时禁用本地 profile 中两个与本插件无关、无法激活的既有插件 `checkpoint-rewind`/`lsp-actions`）：完整回合完成，exit=0，模型真实回复。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-skill-pack-security | [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本；`dsh plugin add @perrylink/dsh-skill-pack-security-provider` 一键挂载 |

## 备注

- 运行级状态按实际填「待测」：未经过本仓库 k8s 实测流程；本地 headless 加载级与完整回合已验证（见自检结果）。
- 本地 headless profile 中 `dsh-checkpoint-rewind` 因等待 `storageDomain` 服务无法激活（与本插件无关），自检经 overlay 临时禁用后通过，未改动 profile 文件。
- 获得 `dsh-external` 维护权限后可迁移命名空间，当前按 README 明文使用自有 `@perrylink/*` scope。