### PR TITLE
docs: 登记 dsh-full-remote

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -17,6 +17,7 @@
 | dsh-spend | [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | Token 用量统计与预计费用：右下角悬浮窗，按模型/按天/按会话多维聚合，内置供应商知识库自动识别计费计划（web bundle） | ✅ |
 | dsh-tray | [qing3a/dsh-tray](https://github.com/qing3a/dsh-tray) | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 | ✅ |
 | dsh-lan-access | [Leon0555/dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) | 局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃），npm 可装 | ✅ |
+| dsh-full-remote | [JUANWANG-BUAA/dsh-full-remote](https://github.com/JUANWANG-BUAA/dsh-full-remote) | 令牌反向代理：改写 Host/Origin，远程恢复 `settings.*`/`credentials.*`/`host.listDirectory`（通用隧道会 403）；一次性扫码邀请、按设备会话；npm `dsh-full-remote` | ✅ |
 | dsh-bash-terminal | [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) | Windows 三终端 shell 工具（PowerShell/Git Bash/WSL，默认终端由用户在设置中选择）+ 交互式 PTY 终端 + 官方沙箱对接；4 套件测试 + GitHub Actions CI 全绿 | ✅ |
 | dsh-artifact | [dsh-external/dsh-artifact](https://github.com/dsh-external/dsh-artifact) | 制品管理 | ✅ |
 | dsh-split-panes | [dsh-external/dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) | 分屏面板 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-full-remote |
| 仓库 | https://github.com/JUANWANG-BUAA/dsh-full-remote |
| 一句话说明 | 令牌反向代理：改写 Host/Origin，远程恢复 `settings.*` / `credentials.*` / `host.listDirectory`（通用隧道会 403）；一次性扫码邀请、按设备会话。 |
| 版本 | 0.2.4（npm `dsh-full-remote`） |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 为作者控制的未限定包名 `dsh-full-remote`（未占用 `@deepseek-ai/*`，也未使用无维护权限的 `@dsh-external/*`）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已允许维护者编辑 PR
- [x] 所有运行时依赖已声明
- [x] 已按自检实测通过

自检结果：

- DeepSeek Harness web profile（`dsh --profile web`），本机 `127.0.0.1:3080`
- 验证日期：2026-08-16
- npm `dsh-full-remote@0.2.4`；CI `check:ci` 与 provenance 发布已通过
- 设置 → 反向代理：启动监听、栅栏自检 `settings.describe` HTTP 200、一次性邀请登录

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-full-remote | [JUANWANG-BUAA/dsh-full-remote](https://github.com/JUANWANG-BUAA/dsh-full-remote) | 令牌反向代理：改写 Host/Origin，远程恢复 `settings.*`/`credentials.*`/`host.listDirectory`（通用隧道会 403）；一次性扫码邀请、按设备会话；npm `dsh-full-remote` |

## 备注

- 插在 `dsh-lan-access` 后：同属远程/局域网访问，本插件补鉴权与特权接口改写。
- 面向 web profile，不适用于 headless。
- 运行级 ✅ 依据：作者本机 web profile 实测 + npm 已发布。欢迎雷达复核。


Made with [Cursor](https://cursor.com)