### PR TITLE
docs: dsh-update-notifier 实测状态更新

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -95,8 +95,7 @@
 |---|---|---|---|
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |
 | dsh-subagent-cwd | [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) | dsh-subagent-tools 加按次 cwd（子代理工作目录），附两处进程内 provider 补丁；rc.6 前台/后台 cwd 实测通过 | ✅ |
-| dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体更新提醒：npm latest 高于本地版本时侧边栏左下角红点+Modal（复制更新命令/忽略此版本/稍后再说），官方 ui-primitives 渲染，无更新零 UI；零构建、25 单测、rc.5/rc.6 加载与端点 E2E 实测 | 待测 |
-| dsh-enhancement-suite | [Scorp1o117/dsh-enhancement-suite](https://github.com/Scorp1o117/dsh-enhancement-suite) | 四个 Scorp1o117 DSH 插件的官方总入口 + 一键安装器（list/install/update/doctor，--profile/--only/--dry-run）：零依赖，走官方 dsh plugin CLI 并安全自动挂载；npm 已发布 | 待测 |
+| dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体更新提醒：npm latest 高于本地版本时侧边栏左下角红点+Modal（复制更新命令/忽略此版本/稍后再说），官方 ui-primitives 渲染，无更新零 UI；零构建、25 单测、rc.5/rc.6 加载与端点 E2E 实测 | ✅ || dsh-enhancement-suite | [Scorp1o117/dsh-enhancement-suite](https://github.com/Scorp1o117/dsh-enhancement-suite) | 四个 Scorp1o117 DSH 插件的官方总入口 + 一键安装器（list/install/update/doctor，--profile/--only/--dry-run）：零依赖，走官方 dsh plugin CLI 并安全自动挂载；npm 已发布 | 待测 |
 
 ## 🎓 技能
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-update-notifier |
| 仓库 | https://github.com/arvin-yd/dsh-update-notifier |
| 一句话说明 | DSH 本体更新提醒（状态证据更新：待测 → ✅，附社区 L4 实测证据） |
| 版本 | 0.2.0 |

## 状态证据（社区自测，非官方 runner）

**环境**：mainline `47f94385`（`0.1.0-rc.5`），npm `latest` = `0.1.0-rc.6`（真实更新场景）；Node 25.8.1 / pnpm 11.7。

### L4 运行级：headless 任务回路（mock-llm，无凭证）

```sh
# 官方 @deepseek-ai/dsh-llm-mock-server（test-support）
pnpm run mock:llm --port 8000 --api-key mock-key --sequence success
# 插件已装入 headless profile，跑真实任务回路
DEEPSEEK_BASE_URL=http://127.0.0.1:8000/v1 DEEPSEEK_API_KEY=mock-key \
  dsh --profile headless "reply with exactly: hello world"
```

结果：**exit 0**，turn 完成（`mock response recovered`），**插件零报错**——未阻塞/污染 agent loop。

### L4 运行级：web 端点（同一 mainline 全新 boot）

```json
GET /dsh-update-check
{"state":"update-available","current":"0.1.0-rc.5","latest":"0.1.0-rc.6","fetchedAt":1786865962084,"error":null,"updateHint":"npm install -g @deepseek-ai/dsh@latest"}
```

- `?force=1` 手动刷新正常（冷却 2s）；`405` 非 GET 方法拦截正常。
- 单元套件：**25/25**（vitest + jsdom 注册冒烟测试）。
- 完整证据（含历史 rc.5/rc.6 E2E 与缺陷修复记录）：[VERIFICATION.md](https://github.com/arvin-yd/dsh-update-notifier/blob/main/VERIFICATION.md)

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | 状态 待测 → ✅；说明追加社区 L4 实测证据链接 |

## 备注

- 若官方 runner 后续给出不同结论，请以 runner 结果覆盖本状态即可（`sync-runtime` 正常流程）。
- 证据限定的环境与 commit 已在正文注明；未在浏览器中人工点击 UI 徽标（该链路由 jsdom 冒烟测试覆盖）。
