### PR TITLE
docs: 登记 dsh-anchored-subagent

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -86,7 +86,7 @@
 | dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 | 待测 |
 | dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
 | dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
-| dsh-anchored-subagent | [GY-Bai/dsh-anchored-subagent](https://github.com/GY-Bai/dsh-anchored-subagent) | DSH 插件：主 agent 和子代理首轮以 Minimal（bash + str_replace_editor + Minimal persona）开局，第二轮恢复完整工具；自定义子代理 persona 首轮剥离、第二轮后恢复；dsh.bundle 自动安装 agent preset | ✅ |
+| dsh-anchored-subagent | [GY-Bai/dsh-anchored-subagent](https://github.com/GY-Bai/dsh-anchored-subagent) | 让 DSH 主 agent 和子代理别一开口就 `Let me...`：首轮用 Minimal 开局进入满血状态，第二轮恢复全部工具；自定义子代理角色首轮先收起来，第二轮再放出来 | ✅ |
 
 ## 🧰 插件集
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -86,6 +86,8 @@
 | dsh-tdai-memory | [Scorp1o117/dsh-tdai-memory](https://github.com/Scorp1o117/dsh-tdai-memory) | TencentDB Agent Memory 的 DSH 移植：L0 对话捕获 → L1 结构化记忆提取 → L2 场景/L3 画像，自动召回注入 + 记忆/对话搜索工具；复用现有 ~/.memory-tencentdb 数据；附 Web UI 设置栏 | 待测 |
 | dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
 | dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
+| dsh-anchored-subagent | [GY-Bai/dsh-anchored-subagent](https://github.com/GY-Bai/dsh-anchored-subagent) | DSH 插件：主 agent 和子代理首轮以 Minimal（bash + str_replace_editor + Minimal persona）开局，第二轮恢复完整工具；自定义子代理 persona 首轮剥离、第二轮后恢复；dsh.bundle 自动安装 agent preset | ✅ |
+
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
<!--
  插件登记 PR 模板 —— 按此格式提交，合并后立即进入目录。
  目标文件：PLUGINS.md（表格追加一行即可）。
-->

> 🗣️ **说人话**：这个插件就是让 DSH 的子代理别一上来就 `Let me...`。它先让子代理用 DeepSeek 最熟悉的 Minimal 方式开局（`bash + str_replace_editor` + 一句话 persona），第二轮开始再把所有工具还给它。简单说：**先让模型进入满血状态，再放开手脚**。

> 📌 **标题格式**：`docs: 登记 <插件名>`（示例：`docs: 登记 dsh-balance`）——请勿使用其他标题格式。
>
> 🛠 **合并小贴士（重要）**：请让维护者能帮你 rebase——两种方式任选其一：
> 1. 提交 PR 后，在 PR 页面右侧勾选 **Allow edits from maintainers**；
> 2. 或在自己 fork 仓库的 Settings → General 勾选 **Allow edits and access to secrets by maintainers**（一次开启，以后所有 PR 自动允许）。
>
> 🙏 **致歉说明**：最近 README/PLUGINS.md 正在高速更改中（每日快照更新 + 分类体系重构），多个 PR 同时登记同一区域时可能产生冲突，处理可能稍显延迟，请见谅。

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-anchored-subagent |
| 仓库 | https://github.com/GY-Bai/dsh-anchored-subagent |
| **分类** | 🤖 Agent 能力 |
| 一句话说明 | 让 DSH 主 agent 和子代理别一开口就 `Let me...`：首轮用 Minimal 开局进入满血状态，第二轮恢复全部工具；自定义子代理角色首轮先收起来，第二轮再放出来 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）——说明：使用自有命名空间 `dsh-anchored-subagent`
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（已勾选）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已按自检三步实测通过：

```bash
# 1. 安装最新 dsh 并加载你的插件
dsh plugin add github:GY-Bai/dsh-anchored-subagent
# 2. 无报错即通过加载级
# 3. 运行时依赖：零依赖（仅使用 DSH 内置 API）
```

- [x] 自检结果贴这里：加载成功；web profile 真机 E2E 验证通过——子代理首轮 Minimal persona + `We need...` 轨迹 + 仅 `bash` 工具；第二轮后完整工具恢复，自定义 persona 自动恢复。

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-anchored-subagent | [GY-Bai/dsh-anchored-subagent](https://github.com/GY-Bai/dsh-anchored-subagent) | 让 DSH 主 agent 和子代理别一开口就 `Let me...`：首轮用 Minimal 开局进入满血状态，第二轮恢复全部工具；自定义子代理角色首轮先收起来，第二轮再放出来 |

## 备注

- 分类预归类器建议 `🛒 市场与管理`，但按 taxonomy v2 边界应归 `🤖 Agent 能力`（核心是子代理/agent 能力）。
- 插件已添加 `dsh-plugin` topic，README 中英双语，含安装/配置/测试说明。
