### PR TITLE
docs: 登记 dsh-smooth-stream

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -89,6 +89,7 @@
 | dsh-tool-vision | [Scorp1o117/dsh-tool-vision](https://github.com/Scorp1o117/dsh-tool-vision) | 外置视觉模型插件：inspect_image 把本地图片或 http(s) 图片 URL 发给任意 OpenAI 兼容端点，视觉模型看图的文字回答直接带回对话；附 Web UI 设置栏 | ✅ |
 | dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
 | dsh-anchored-subagent | [GY-Bai/dsh-anchored-subagent](https://github.com/GY-Bai/dsh-anchored-subagent) | 让 DSH 主 agent 和子代理别一开口就 `Let me...`：首轮用 Minimal 开局进入满血状态，第二轮恢复全部工具；自定义子代理角色首轮先收起来，第二轮再放出来 | ✅ |
+| dsh-smooth-stream | [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) | DSH Web 界面丝滑流式渲染：打字机跟随 token 到达、Markdown 边流边渲染、换行滑入、不闪烁，滚动归用户，尊重 prefers-reduced-motion | 待测 |
 
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-smooth-stream |
| 仓库 | https://github.com/Laplace-bit/dsh-smooth-stream |
| **分类** | 🔌 Web UI 增强（taxonomy v2；classify.py 兜底为「其他」，按边界规则「增改功能（新面板/新交互）→ Web UI 增强」归此类） |
| 一句话说明 | DSH Web 界面丝滑流式渲染：打字机跟随 token 到达、Markdown 边流边渲染、换行滑入、不闪烁，滚动归用户，尊重 prefers-reduced-motion |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用 `dsh-smooth-stream`（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies`，官方 `@deepseek-ai/*` 包均走 peer）
- [ ] 已按自检三步实测通过：本插件是 Web UI 客户端插件（`dsh.client.platform: web`），在 headless profile 下无可见 UI，无法用 headless 加载级自检覆盖；`dsh.bundle.patch`（`cordis.patch.yml`）已声明、仓库可经 `dsh plugin add github:Laplace-bit/dsh-smooth-stream` 安装，host 日志应出现 `[dsh-smooth-stream] plugin loaded!`。建议维护者用 Web profile 实测。

## 改动内容

- `PLUGINS.md`「🔌 单插件」末尾追加一行（运行级标注「待测」，未做过 k8s 运行级验证）。