### PR TITLE
docs: 登记 dsh-quant-data-mcp

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -183,3 +183,4 @@
 | dsh-openviking | [Rxiain/dsh-openviking](https://github.com/Rxiain/dsh-openviking) | OpenViking 检索、资源管理、自动召回与会话记忆：memsearch/memfind 等 10 个工具、已索引仓库上下文注入、自动召回注入、会话同步+自动提交 | ✅ |
 | dsh-session-hotkeys | [YEYEYEYESHIFU/dsh-session-hotkeys](https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys) | Web UI 会话快捷键：Alt+1-9 顺序切换、固定槽位三态、Alt+↑↓ 循环切换、高亮导航模式、归档/重命名/新建会话、可改键面板（键盘导航 + 内置诊断），Windows/macOS 双预设无冲突，npm 已发布 | 待测 |
 | dsh-result-only-view | [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 | 待测 |
+| dsh-quant-data-mcp | [helibeiqi/dsh-quant-data-mcp](https://github.com/helibeiqi/dsh-quant-data-mcp) | 零依赖 MCP stdio server 模板 + 开箱即用 A 股数据工具：无需 API Key、纯 NDJSON 协议、路径全走环境变量、可 `dsh plugin add` 一键挂载的 dsh bundle | 待测 |


### PR DESCRIPTION
> 📌 **标题格式**：`docs: 登记 dsh-quant-data-mcp`

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-quant-data-mcp |
| 仓库 | https://github.com/helibeiqi/dsh-quant-data-mcp |
| **分类** | 🔌 单插件 |
| 一句话说明 | 零依赖 MCP stdio server 模板 + 开箱即用 A 股数据工具：无需 API Key、纯 NDJSON 协议、路径全走环境变量、可 `dsh plugin add` 一键挂载的 dsh bundle |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-quant-data-mcp`（未占用 `@dsh-external/*` 也未被 `@deepseek-ai/*` 保留 namespace 占用）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已允许 maintainer 编辑（API `maintainer_can_modify=true`）
- [x] 所有运行时依赖已声明：本插件零依赖，仅 `engines.node>=18`
- [x] 本地实测：dsh v0.1.0-rc.6 web profile 下 `setup.ps1` 安装后 stdio server 正常拉起、6 个 `mcp__quant_data__*` 工具成功注册；**尚未**跑模板里的 headless `--patch` 加载级命令，故运行级标「待测」

## 改动内容

PLUGINS.md `## 🔌 单插件` 表追加一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-quant-data-mcp | [helibeiqi/dsh-quant-data-mcp](https://github.com/helibeiqi/dsh-quant-data-mcp) | 零依赖 MCP stdio server 模板 + 开箱即用 A 股数据工具：无需 API Key、纯 NDJSON 协议、路径全走环境变量、可 `dsh plugin add` 一键挂载的 dsh bundle | 待测 |

## 备注

- 仓库经 A/B 多源审计，无硬编码绝对路径、无 API key（全部环境变量化）。
- 数据源均为公开免密钥端点（东方财富 / 腾讯），适合量化研究在本地把 A 股行情/财务/资金流喂给 DSH agent。
- README 已含 Overview / Compatibility / Install / Uninstall / Quick start / Configuration / License，满足最低收录条件。
