### PR TITLE
docs: 登记 dsh-self-evolving

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -184,3 +184,4 @@
 | dsh-session-hotkeys | [YEYEYEYESHIFU/dsh-session-hotkeys](https://github.com/YEYEYEYESHIFU/dsh-session-hotkeys) | Web UI 会话快捷键：Alt+1-9 顺序切换、固定槽位三态、Alt+↑↓ 循环切换、高亮导航模式、归档/重命名/新建会话、可改键面板（键盘导航 + 内置诊断），Windows/macOS 双预设无冲突，npm 已发布 | 待测 |
 | dsh-result-only-view | [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 | 待测 |
 | dsh-quant-data-mcp | [helibeiqi/dsh-quant-data-mcp](https://github.com/helibeiqi/dsh-quant-data-mcp) | 零依赖 MCP stdio server 模板 + 开箱即用 A 股数据工具：无需 API Key、纯 NDJSON 协议、路径全走环境变量、可 `dsh plugin add` 一键挂载的 dsh bundle | 待测 |
+| dsh-self-evolving | [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) | 证据优先的 DSH 自进化引擎（标准 Cordis controller/service）：有界生成 Cordis 候选插件，一次性真实 Loader 隔离准入，Harbor 评估，可崩溃恢复的 journal 谱系；291 单测 + 36 Loader E2E | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-self-evolving |
| 仓库 | https://github.com/timwhitez/dsh-self-evolving |
| **分类** | 📚 学习研究（预归类器命中：评测） |
| 一句话说明 | 证据优先的 DSH 自进化引擎（标准 Cordis controller/service）：有界生成 Cordis 候选插件，一次性真实 Loader 隔离准入，Harbor 评估，可崩溃恢复的 journal 谱系 |

## 自检清单

- [x] package.json name 使用非保留 scope：`@dsh-self-evolving/core`（未占用 `@deepseek-ai/*`）
- [x] 仓库已打 `dsh-plugin` topic（另有 `dsh` topic）
- [x] 已在 fork Settings → General 开启 Allow edits and access to secrets by maintainers
- [x] 所有运行时依赖已声明
- [x] 自检：仓库自带 36 项真实 Cordis Loader E2E + 291 单测全绿（v0.2.0 验收审计）；本机未重复执行模板中的 headless 命令，运行级按「待测」登记

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-self-evolving | [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) | 证据优先的 DSH 自进化引擎（标准 Cordis controller/service）：有界生成 Cordis 候选插件，一次性真实 Loader 隔离准入，Harbor 评估，可崩溃恢复的 journal 谱系；291 单测 + 36 Loader E2E |