### PR TITLE
docs: 更新 dsh-mcp-panel 描述（0.4.0 MCP 管理控制台）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -141,7 +141,7 @@
 | dsh-file-review | [left0ver/dsh-file-review](https://github.com/left0ver/dsh-file-review) | 文件审查插件：diff 的形式查看文件的修改内容，方便对 agent 的修改进行审查 | ✅ |
 | dsh-file-claim | [Nwflower/dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) | 同一工作区并行多会话的文件认领与写入保护（claim/release、心跳 stale 接管、pending 三路合并） | ✅ |
 | dsh-memento | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | 有界、分层、审批门、可审计的跨会话记忆接缝：ctx.memory 服务 + 本地 SQLite（零依赖）+ memory 工具 + 冻结快照注入；写必审批、模型可见 ⟺ 落盘 | ✅ |
-| dsh-mcp-panel | [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | 官方 MCP 客户端（dsh-mcp-client）只读运行时管理面板：/mcp 命令 + 设置页 MCP 页签展示连接状态/已注册工具/错误/重连计数，脱敏展示与受控启停 patch 建议 | 待测 |
+| dsh-mcp-panel | [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | 官方 MCP 客户端（dsh-mcp-client）管理控制台：/mcp 命令 + 设置页 MCP 页签提供服务器增删改（审批门 + 自动备份的只追加 profile 写入）、走官方工具管线的工具试用台、健康诊断与连接状态；npm 0.4.0，全量门禁绿（142 测试） | 待测 |
 | dsh-auto-continue | [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | DSH Web 请求中断自动续跑插件：回合因网络/超时等非人为原因失败后自动发送「继续」续跑（含宿主崩溃遗留回合扫描恢复），全部参数可在设置→插件配置中调整 | ✅ |
 | sandbase-harness | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | DSH bundle for SandBase managed-agents, exposing agent discovery, durable sessions, streamed runs, artifacts, and cancellation over stdio MCP; verified against DSH 47f9438 | ✅ |
 | sandbase-skills | [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) | Research and growth skill collection with an npm CLI that installs complete bundles into DSH native .dsh/skills discovery root; verified against DSH 47f9438 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-mcp-panel |
| 仓库 | https://github.com/PerryLink/dsh-mcp-panel |
| **分类** | 🛠 基建部署（taxonomy v2 边界规则：MCP 接入 → 基建部署；条目当前位于 ❓ 未分类表，本次仅修正描述，归类请以分类器为准） |
| 一句话说明 | 官方 MCP 客户端（dsh-mcp-client）管理控制台：/mcp 命令 + 设置页 MCP 页签提供服务器增删改（审批门 + 自动备份的只追加 profile 写入）、走官方工具管线的工具试用台、健康诊断与连接状态 |

## 自检清单（提交前逐项确认）

- [ ] package.json `name` 使用 `@dsh-external/*` scope —— 未勾选：当前使用自有命名空间（unscoped `dsh-mcp-panel`），未占用 `@deepseek-ai/*` 保留命名空间；获得 dsh-external 维护权限后再迁移
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（经 API maintainer_can_modify=true 设置）
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 已按自检三步实测通过（加载级；Windows 无进程替换，改用等价临时 patch/沙箱写法，见下）

**自检结果**（真实执行输出）：

```
$ dsh --version
0.1.0-rc.6
$ dsh plugin --profile headless add dsh-mcp-panel@0.4.0   # 沙箱临时 DSH_HOME（mkdtemp）
Packages: +35
Done in 1.4s using pnpm v11.7.0
$ dsh --profile headless hi
dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route deepseek-official;
store DEEPSEEK_API_KEY through the credentials service ...
```

加载级通过：profile 组装与插件行加载无错误，启动推进到首次模型调用才因本机无 `DEEPSEEK_API_KEY` 报 MISSING_CREDENTIAL；模型回路与工具调用未验证。插件自身全量门禁绿（typecheck + typecheck:ci + 142 tests + build + verify:self-contained + verify:artifacts + pack）。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-mcp-panel | [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | 官方 MCP 客户端（dsh-mcp-client）管理控制台：/mcp 命令 + 设置页 MCP 页签提供服务器增删改（审批门 + 自动备份的只追加 profile 写入）、走官方工具管线的工具试用台、健康诊断与连接状态；npm 0.4.0，全量门禁绿（142 测试） |

## 备注

- 本次仅修正既有条目描述（原行位于 ❓ 未分类表），运行级状态保持「待测」——未跑过本仓库的 k8s 实测流程，如实不填「运行级可用」。
- 当前使用自有命名空间（unscoped），获得 dsh-external 维护权限后再迁移。