### PR TITLE
docs: 登记 dsh-background-agents

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -90,6 +90,7 @@
 | dsh-compressor | [lifeodyssey/dsh-compressor](https://github.com/lifeodyssey/dsh-compressor) | [Headroom](https://github.com/headroomlabs-ai/headroom) 的精简移植，在不影响模型上下文缓存以及 Agent 性能的情况下，压缩工具的输出，至多减少 20% 的上下文。 | 待测 |
 | dsh-anchored-subagent | [GY-Bai/dsh-anchored-subagent](https://github.com/GY-Bai/dsh-anchored-subagent) | 让 DSH 主 agent 和子代理别一开口就 `Let me...`：首轮用 Minimal 开局进入满血状态，第二轮恢复全部工具；自定义子代理角色首轮先收起来，第二轮再放出来 | ✅ |
 
+| dsh-background-agents | [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) | 交互式长会话后台 agent：官方 subagent 接缝上的可持久/可继续子 agent，Web UI 侧边栏实时进度、随时消息/打断、autoReport 进度注入、空闲归档；npm 0.5.0 已发布 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-background-agents |
| 仓库 | https://github.com/PerryLink/dsh-background-agents |
| 分类 | 🤖 Agent 能力（taxonomy v2 规则 7：agent / 子代理 / subagent） |
| 一句话说明 | 官方 subagent 接缝上的交互式长会话后台 agent：可持久/可继续子 agent + Web UI 侧边栏进度 + 随时消息/打断 |

## 自检清单

- [x] 包名使用自有命名空间 `dsh-background-agents`（未占用 `@deepseek-ai/*` 官方保留命名空间；按 README 明文「只有获得 dsh-external 维护权限的项目才应使用 @dsh-external/*」，当前未获该权限，获得后迁移）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [x] 按自检三步实测（Windows 无进程替换，改用等价临时 patch 文件写法）：

```text
# 1. 安装并加载（真实 npm 安装，沙箱 DSH_HOME）
> dsh plugin --profile headless add dsh-background-agents
+ dsh-background-agents ^0.4.0
Done in 5.3s using pnpm v11.7.0
plugin add EXIT: 0

# 2. 无配置启动：插件 Config 要求显式 provider，fail-loud 属设计内
Error: invalid config: - $​.provider missing required value (at provider)

# 3. 按仓库 dev/cordis.yml 在 profile patch 提供 provider: spawn 后启动：
#    插件行成功挂载，启动推进到模型回合，在凭据步骤退出（无插件级错误）
dsh: MISSING_CREDENTIAL: llm-deepseek: no API key for provider route "deepseek-official"
```

- [x] 自检结果：加载级通过（真实 npm 安装 exit 0 + 配置后插件行成功挂载）；完整模型回合因沙箱环境无 API key 未验证（如实说明，不声明「运行级可用」）

## 修改内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-background-agents | https://github.com/PerryLink/dsh-background-agents | 交互式长会话后台 agent：官方 subagent 接缝上的可持久/可继续子 agent，Web UI 侧边栏实时进度、随时消息/打断、autoReport 进度注入、空闲归档；npm 0.5.0 已发布 |

## 备注

- 运行级列如实填「待测」：未跑过本仓库 k8s 实测流程（一插件一 pod），不填「运行级可用」。
- 插件提供 `main`/`exports`/`dsh.bundle`（patch 指向 cordis.patch.yml，含 client 半）；npm `dsh-background-agents@0.5.0`；仓库 CI 全绿（typecheck + test + build drift + pack smoke）。