### PR TITLE
docs: 更新 dsh-memento 说明（dsh-memory-protocol v1）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -145,7 +145,7 @@
 | dsh-plugin-workshop | [yyyyukari/dsh-plugin-workshop](https://github.com/yyyyukari/dsh-plugin-workshop) | 创意工坊式插件浏览器：侧栏常驻入口，搜索/最热/最新/近 7-90 天飙升榜、中文关键词映射、描述与 README 机翻、插件特征验证过滤、一键安装/更新/卸载，内置已安装插件管理（零服务器，GitHub 直连） | ✅ |
 | dsh-file-review | [left0ver/dsh-file-review](https://github.com/left0ver/dsh-file-review) | 文件审查插件：diff 的形式查看文件的修改内容，方便对 agent 的修改进行审查 | ✅ |
 | dsh-file-claim | [Nwflower/dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) | 同一工作区并行多会话的文件认领与写入保护（claim/release、心跳 stale 接管、pending 三路合并） | ✅ |
-| dsh-memento | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | 有界、分层、审批门、可审计的跨会话记忆接缝：ctx.memory 服务 + 本地 SQLite（零依赖）+ memory 工具 + 冻结快照注入；写必审批、模型可见 ⟺ 落盘 | ✅ |
+| dsh-memento | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | 有界、分层、审批门、可审计的跨会话记忆接缝：ctx.memory 服务 + 本地 SQLite（零依赖）+ memory 工具 + 冻结快照注入；写必审批、模型可见 ⟺ 落盘；0.4.0 预演 dsh-memory-protocol v1——适配器注册表（mem0/Hermes/CLAUDE.md 转换）+ 可分发一致性套件 | ✅ |
 | dsh-mcp-panel | [PerryLink/dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) | 官方 MCP 客户端（dsh-mcp-client）管理控制台：/mcp 命令 + 设置页 MCP 页签提供服务器增删改（审批门 + 自动备份的只追加 profile 写入）、走官方工具管线的工具试用台、健康诊断与连接状态；npm 0.4.0，全量门禁绿（142 测试） | 待测 |
 | dsh-auto-continue | [HsiangNianian/dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | DSH Web 请求中断自动续跑插件：回合因网络/超时等非人为原因失败后自动发送「继续」续跑（含宿主崩溃遗留回合扫描恢复），全部参数可在设置→插件配置中调整 | ✅ |
 | sandbase-harness | [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) | DSH bundle for SandBase managed-agents, exposing agent discovery, durable sessions, streamed runs, artifacts, and cancellation over stdio MCP; verified against DSH 47f9438 | ✅ |


### PR DESCRIPTION
﻿## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-memento |
| 仓库 | https://github.com/PerryLink/dsh-memento |
| 分类 | 🧠 记忆增强 |
| 一句话说明 | 有界、分层、审批门、可审计的跨会话记忆接缝；0.4.0 预演 dsh-memory-protocol v1（适配器注册表 + 一致性套件） |

## 自检清单（逐项如实勾选）

- [ ] package.json name 使用 @dsh-external/* scope —— **否**：README 明文「只有获得 dsh-external 维护权限的项目才应使用 @dsh-external/*」；本插件使用自有命名空间 dsh-memento，获得 dsh-external 维护权限后再迁移（README 明文为准）。
- [x] 仓库已打 dsh-plugin topic
- [x] 运行时依赖已声明（peerDependencies：@deepseek-ai/cordis、dsh-session、dsh-tools、schemastery；零运行时 dependencies）
- [x] 自检命令真实执行（Windows 无进程替换，改用等价临时 patch 文件写法）：

`ash
# 临时 patch 文件（等价 <(...) 进程替换）
dsh --profile headless --patch C:\...\Temp\dsh-group3-work\memento-patch.yml "hi"
`

**自检结果**：加载级通过——在临时 DSH_HOME 安装 dsh-memento@0.3.1 后，插件树加载成功（输出出现 dsh-memento 的 node:sqlite ExperimentalWarning 即插件已挂载）；后续失败发生在 LLM 凭据阶段（MISSING_CREDENTIAL: 本机未配置 DEEPSEEK_API_KEY），与插件无关。未验证项：0.4.0 尚未发布 npm，本次自检用已发布 0.3.1 加载；k8s 运行级实测流程未在本机执行，状态列维持原值不擅改。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-memento | [PerryLink/dsh-memento](https://github.com/PerryLink/dsh-memento) | （行内更新）说明追加 0.4.0 协议升级：dsh-memory-protocol v1 适配器注册表 + 可分发一致性套件 |

## 备注

- 本 PR 只更新既有登记行的说明文字，不新增/删除行、不改状态列。
- 描述为小改（仅修正描述），符合 README「仅修正链接、分类、描述或状态证据时，也欢迎直接提交小型 PR」。
