### PR TITLE
docs: 登记 dsh-github

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -185,3 +185,4 @@
 | dsh-result-only-view | [YEYEYEYESHIFU/dsh-result-only-view](https://github.com/YEYEYEYESHIFU/dsh-result-only-view) | Web 对话「只看结果」开关：隐藏思考与工具调用过程，运行中仅保留一条实时状态行，回合结束显示「已处理 N 步」痕迹行可点击展开回看；中英双语，常规设置可配置痕迹行与 reduced-motion 光影策略；npm 已发布 | 待测 |
 | dsh-quant-data-mcp | [helibeiqi/dsh-quant-data-mcp](https://github.com/helibeiqi/dsh-quant-data-mcp) | 零依赖 MCP stdio server 模板 + 开箱即用 A 股数据工具：无需 API Key、纯 NDJSON 协议、路径全走环境变量、可 `dsh plugin add` 一键挂载的 dsh bundle | 待测 |
 | dsh-self-evolving | [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) | 证据优先的 DSH 自进化引擎（标准 Cordis controller/service）：有界生成 Cordis 候选插件，一次性真实 Loader 隔离准入，Harbor 评估，可崩溃恢复的 journal 谱系；291 单测 + 36 Loader E2E | 待测 |
+| dsh-github | [PerryLink/dsh-github](https://github.com/PerryLink/dsh-github) | 官方级 GitHub CI 集成：composite action.yml、轮询 PR 评审机器人（幂等行内评论 + status-check 门禁）、/pr /review /issue 命令族与 12 个 PR/issue 工具，所有写入走人工审批门；npm @perrylink/dsh-github 0.6.1 | 待测 |


### PR DESCRIPTION
更新:dsh-github - https://github.com/PerryLink/dsh-github分类:工具 类(taxonomy v2 对齐 github/ci/review;可评审与集成)一句话描述:官方级 GitHub CI 套件(composite action.yml + 评审机器人 + status-check 门)。

自检:已打 dsh-plugin topic;仓库公开;依赖合规;已验证:npm @perrylink/dsh-github 0.6.1 已发布,全绿门禁(typecheck/test/build/check:readmes);运行级说明:未跑 k8s 实测,按模板最低状态如实标注;登记表行:PLUGINS.md 拟新增一行表格内容如下。