### PR TITLE
docs: 登记 dsh-headroom

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -186,3 +186,4 @@
 | dsh-quant-data-mcp | [helibeiqi/dsh-quant-data-mcp](https://github.com/helibeiqi/dsh-quant-data-mcp) | 零依赖 MCP stdio server 模板 + 开箱即用 A 股数据工具：无需 API Key、纯 NDJSON 协议、路径全走环境变量、可 `dsh plugin add` 一键挂载的 dsh bundle | 待测 |
 | dsh-self-evolving | [timwhitez/dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) | 证据优先的 DSH 自进化引擎（标准 Cordis controller/service）：有界生成 Cordis 候选插件，一次性真实 Loader 隔离准入，Harbor 评估，可崩溃恢复的 journal 谱系；291 单测 + 36 Loader E2E | 待测 |
 | dsh-github | [PerryLink/dsh-github](https://github.com/PerryLink/dsh-github) | 官方级 GitHub CI 集成：composite action.yml、轮询 PR 评审机器人（幂等行内评论 + status-check 门禁）、/pr /review /issue 命令族与 12 个 PR/issue 工具，所有写入走人工审批门；npm @perrylink/dsh-github 0.6.1 | 待测 |
+| dsh-headroom | [WanYanTianDe/dsh-headroom](https://github.com/WanYanTianDe/dsh-headroom) | Headroom 上下文压缩：历史区间压缩（替代 LLM 总结）+ 大工具输出压缩（超阈值自动瘦身）+ CCR 原文取回（headroom_retrieve 工具）；本地代理自动安装/生命周期管理 + 设置卡片；npm 已发布（@wanyantiande/dsh-headroom） | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-headroom |
| 仓库 | https://github.com/WanYanTianDe/dsh-headroom |
| 分类 | 🤖 Agent 能力 |
| 一句话说明 | Headroom 上下文压缩：历史区间压缩（替代 LLM 总结）+ 大工具输出压缩 + CCR 原文取回，本地代理自动安装与生命周期管理，npm 已发布 |

## 自检清单

- [x] package.json name 使用个人作用域 `@wanyantiande/dsh-headroom`（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic（已 public）
- [x] 所有运行时依赖已声明（peerDependencies 全量声明 `@deepseek-ai/*` 与 react）
- [x] 自检结果：web profile 实测加载 active，`ctx.compaction` 为 HeadroomCompactionEngine，本地代理 8787 就绪；vitest 37 例全过；npm `@wanyantiande/dsh-headroom@0.2.0` 已发布且 `npm install` 验证通过

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-headroom | [WanYanTianDe/dsh-headroom](https://github.com/WanYanTianDe/dsh-headroom) | Headroom 上下文压缩：历史区间压缩 + 大工具输出压缩 + CCR 原文取回（headroom_retrieve）；本地代理自动安装/生命周期管理 + 设置卡片；npm 已发布 |

## 备注

- 运行级标记为"待测"，等待雷达 k8s 实测后更新。
- 与同表 dsh-compressor 定位互补（本插件同时覆盖历史压缩与工具输出压缩，取回统一走 headroom_retrieve）。