### PR TITLE
docs: 登记 dsh-session-pin（导航组织器）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -7,6 +7,7 @@
 > 约定：插件名与 repo 名一致；scope 使用 `@dsh-external/*`（勿占用 `@deepseek-ai/*` 保留命名空间）；repo 打 `dsh-plugin` topic。
 
 ## 🔌 单插件
+| dsh-session-pin | [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 会话与工作区置顶（双面 host+client）：行级图钉与换色、会话头开关、已置顶面板、持久化 settings 命名空间；0.4.0 再加会话导航组织器——Pin 分组（boards）、标签与保存视图、会话健康摘要（只读脱敏）与 /goto 模糊跳转；全部浏览器本地零网络 | 待测 |
 
 | 插件 | 仓库 | 说明 | 运行级 |
 |---|---|---|---|


### PR DESCRIPTION
﻿## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-session-pin |
| 仓库 | https://github.com/PerryLink/dsh-session-pin |
| 分类 | 🔌 Web UI 增强（会话导航） |
| 一句话说明 | 会话/工作区置顶 + 0.4.0 导航组织器（boards、标签、保存视图、健康摘要、/goto） |

## 自检清单（逐项如实勾选）

- [ ] package.json name 使用 @dsh-external/* scope —— **否**：README 明文「只有获得 dsh-external 维护权限的项目才应使用 @dsh-external/*」；本插件使用自有命名空间 dsh-session-pin，获得维护权限后再迁移。
- [x] 仓库已打 dsh-plugin topic
- [x] 运行时依赖已声明（peerDependencies：@deepseek-ai/cordis、dsh-settings、dsh-client-*；浏览器依赖走 dsh.client inject）
- [x] 自检命令真实执行：本插件为浏览器行为插件（host 仅注册 settings 命名空间），host 加载级通过；k8s 运行级实测流程未在本机执行，状态列按模板如实填「待测」。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-session-pin | [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 新登记行（此前仅自动扫描收录，未登记单插件表） |
