### PR TITLE
docs: 登记 dsh-translate

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -189,3 +189,4 @@
 | dsh-headroom | [WanYanTianDe/dsh-headroom](https://github.com/WanYanTianDe/dsh-headroom) | Headroom 上下文压缩：历史区间压缩（替代 LLM 总结）+ 大工具输出压缩（超阈值自动瘦身）+ CCR 原文取回（headroom_retrieve 工具）；本地代理自动安装/生命周期管理 + 设置卡片；npm 已发布（@wanyantiande/dsh-headroom） | 待测 |
 | dsh-click | [PerryLink/dsh-click](https://github.com/PerryLink/dsh-click) | Windows 优先的原生桌面控制：截图、无障碍树结构化读取、点击/输入/滚动/按键、应用启动，变更性操作过审批门禁、屏幕变化拒绝执行、操作前后校验进程身份 | 待测 |
 | dsh-session-sync | [PerryLink/dsh-session-sync](https://github.com/PerryLink/dsh-session-sync) | 跨设备会话同步：专用 git 镜像 + 仅追加的双方保留冲突裁决（本地保留、远端留存 fork 文件，绝不静默覆盖），/sync 命令与 sync_status/sync_pull/sync_push 工具，自动推拉可配；49 测试 + 真实 git e2e 全绿，rc.6 --patch 加载实测通过 | 待测 |
+| dsh-translate | [PerryLink/dsh-translate](https://github.com/PerryLink/dsh-translate) | 厂商参数翻译与确定性 JSON 修复：/translate 命令映射 11 家厂商的 13 个规范参数；post-execute 修复层 + fix_json 工具修复工具输出中的坏 JSON（转义/去尾逗号/截断闭合/null 占位补全），绝不编造数据 | 待测 |


### PR DESCRIPTION
## 登记信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-translate |
| 仓库 | https://github.com/PerryLink/dsh-translate |
| **分类** | 工具 类(定位:参数翻译 + JSON 修复层) |
| 一句话描述 | 厂商参数翻译与确定性 JSON 修复:/translate 映射 11 厂商共 13 类参数;post-execute 修复层 + fix_json 修复破损的 JSON(缺逗号/坏转义/截断/null 等),不编造数据 |

## 自检(提交前自查)

- [x] package.json `name` 无@ scope 使用 `dsh-translate`(未用 `@deepseek-ai/*` 命名空间;README 无 `@dsh-external/*` scope,未授权 scope 不用,如需 dsh-external 授权请告知迁移,谢谢)
- [x] 已打 `dsh-plugin` topic(含 dsh / deepseek-harness / deepseek / cordis / json-repair / schema-validation / parameter-mapping / llm-api / tooling)
- [x] 本 PR 勾选 **Allow edits from maintainers**(API 实测 `allow_maintainer_edit: true`)
- [x] 依赖声明符合规范(peerDependencies 含 `@deepseek-ai/dsh-*@0.1.0-rc.6`、`@deepseek-ai/cordis`、`@deepseek-ai/schemastery`)
- [x] 真实执行自检通过(Windows 实测,用临时 patch 文件代替,如下)

```text
# Windows 实测:临时 patch 文件 + 加载验证
> dsh --profile headless --patch %TEMP%\dsh-translate-selfcheck-patch.yml --dump-config
# == C:\Users\...\dsh-translate-selfcheck-patch.yml
- id: dsh-translate
  name: dsh-translate
exit=0(加载成功,无 FAILED)
```

- [x] 模型验证:通过(row 输出含 dump-config 行且加载 exit 0)真实对话("hi" 有响应)备注:未配置 DEEPSEEK_API_KEY,未跑在线推理;真实调用链路待验证;另附:本地 node --test 57 全绿且 checkJs 全过且 tarball 装到 scratch profile 冒烟测试全部通过

## 登记表行

| 插件 | 仓库 | 描述 |
|---|---|---|
| dsh-translate | [PerryLink/dsh-translate](https://github.com/PerryLink/dsh-translate) | 厂商参数翻译与确定性 JSON 修复:/translate 映射 11 厂商共 13 类参数;post-execute 修复层 + fix_json 修复破损的 JSON(缺逗号/坏转义/截断/null 等),不编造数据 |

## 备注

- 当前包名使用裸名发布 `dsh-translate`(无 scope),如 dsh-external 授权请告知迁移 `@dsh-external/*`。
- 运行级状态如实填写:未跑标准件 D k8s 实测