### PR TITLE
docs: 登记 dsh-observe

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -190,3 +190,4 @@
 | dsh-click | [PerryLink/dsh-click](https://github.com/PerryLink/dsh-click) | Windows 优先的原生桌面控制：截图、无障碍树结构化读取、点击/输入/滚动/按键、应用启动，变更性操作过审批门禁、屏幕变化拒绝执行、操作前后校验进程身份 | 待测 |
 | dsh-session-sync | [PerryLink/dsh-session-sync](https://github.com/PerryLink/dsh-session-sync) | 跨设备会话同步：专用 git 镜像 + 仅追加的双方保留冲突裁决（本地保留、远端留存 fork 文件，绝不静默覆盖），/sync 命令与 sync_status/sync_pull/sync_push 工具，自动推拉可配；49 测试 + 真实 git e2e 全绿，rc.6 --patch 加载实测通过 | 待测 |
 | dsh-translate | [PerryLink/dsh-translate](https://github.com/PerryLink/dsh-translate) | 厂商参数翻译与确定性 JSON 修复：/translate 命令映射 11 家厂商的 13 个规范参数；post-execute 修复层 + fix_json 工具修复工具输出中的坏 JSON（转义/去尾逗号/截断闭合/null 占位补全），绝不编造数据 | 待测 |
+| dsh-observe | [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) | 可观测性导出：session/event 流转为 OTLP traces+metrics 与 Langfuse 观测（turn/step/tool/LLM span、token/成本计数、脱敏 prompt/completion），异步批量 + 有界持久离线缓冲 + 退避重试，默认关闭显式开启 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-observe |
| 仓库 | https://github.com/PerryLink/dsh-observe |
| **分类** | 🔌 单插件（可观测性/导出器：session/event → OTLP + Langfuse） |
| 一句话说明 | 可观测性导出：session/event 流转为 OTLP traces+metrics 与 Langfuse 观测（turn/step/tool/LLM span、token/成本计数、脱敏 prompt/completion），异步批量 + 有界持久离线缓冲 + 退避重试，默认关闭显式开启 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-observe`（未占用 `@deepseek-ai/*` 保留命名空间；README 要求 `@dsh-external/*` scope，当前未获该 scope 授权，待获得 dsh-external 维护权限后迁移，见备注）
- [x] 仓库已打 `dsh-plugin` topic（同时含 dsh / deepseek-harness / deepseek / cordis / observability / opentelemetry / otlp / langfuse / tracing）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（API 开启 `allow_maintainer_edit: true`）
- [x] 所有运行时依赖已声明（peerDependencies 钉 `@deepseek-ai/dsh-*@0.1.0-rc.6`、`@deepseek-ai/cordis`、`@deepseek-ai/schemastery`；zod 为运行时 wire schema 依赖；typescript/tsdown 为 git 通道 prepare 构建用 dependencies）
- [x] 已按自检三步实测（Windows 无进程替换，改用等价临时 patch 文件写法，见下）

```text
# Windows 等价自检：临时 patch 文件 + 加载级验证
> dsh --profile headless --patch %TEMP%\dsh-observe-selfcheck-patch.yml --dump-config
# == C:\Users\...\dsh-observe-selfcheck-patch.yml
- id: dsh-observe
  name: dsh-observe
exit=0（加载级通过，无 FAILED）
```

- [x] 自检结果：加载级通过（row 正常挂载、dump-config 输出完整行、exit 0）。任务级（"hi" 完整对话）未执行：本机未配置 DEEPSEEK_API_KEY，无法发起模型请求；已如实标注「待测」。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-observe | [PerryLink/dsh-observe](https://github.com/PerryLink/dsh-observe) | 可观测性导出：session/event 流转为 OTLP traces+metrics 与 Langfuse 观测，异步批量 + 有界持久离线缓冲 + 退避重试，默认关闭显式开启 |

## 备注

- 当前使用自有命名空间 `dsh-observe`（无 scope），获得 dsh-external 维护权限后再迁移到 `@dsh-external/*`。
- 运行状态如实填「待测」：未跑过本仓库 k8s 实测流程；本机已完成 vitest 95 测试全绿（真实 Context/Session/storage 接缝）+ tarball 装入 scratch profile 的安装冒烟。
