### PR TITLE
docs: 登记 dsh-budget

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -197,3 +197,4 @@
 | dsh-feishu | [PGZXB/dsh-feishu](https://github.com/PGZXB/dsh-feishu) | DeepSeek Harness 的飞书 UI：面板驱动控制台，卡内审批与提问，流式卡片，扫码一键配置 | 待测 |
 | dsh-draw | [PerryLink/dsh-draw](https://github.com/PerryLink/dsh-draw) | 统一静态图像生成路由：单一 image_generate 工具 + 标准参数，配置驱动的 OpenAI 兼容引擎路由（OpenAI Images、智谱 CogView 及任意兼容端点）与健康感知回退，工作区持久附件结果、按会话配额记账、对话内结果卡片，API key 存为凭据引用 | 待测 |
 | dsh-library | [PerryLink/dsh-library](https://github.com/PerryLink/dsh-library) | 本地优先文档知识库：library_add/remove/list、语义+关键词混合 library_search（多样性重排、相关性过滤、避免 lost-in-the-middle）、引用感知注入与 library_cite_check/diagnose，SQLite 索引 + 本地嵌入，零模型下载 | 待测 |
+| dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-budget |
| 仓库 | https://github.com/PerryLink/dsh-budget |
| **分类** | 🔌 单插件（成本治理：token/费用计量 + 预算上限 + 超限策略） |
| 一句话说明 | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-budget`（未占用 `@deepseek-ai/*` 保留命名空间；README 要求 `@dsh-external/*` scope，当前未获该 scope 授权，待获得 dsh-external 维护权限后迁移，见备注）
- [x] 仓库已打 `dsh-plugin` topic（同时含 dsh / deepseek-harness / deepseek / cordis / budget / cost-tracking / carbon-footprint / latency-benchmark / token-usage）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（API 开启 `maintainer_can_modify: true`）
- [x] 所有运行时依赖已声明（peerDependencies 钉 `@deepseek-ai/dsh-*@0.1.0-rc.6`、`@deepseek-ai/cordis`、`@deepseek-ai/schemastery`；typescript/tsdown 为 git 通道 prepare 构建用 dependencies）
- [x] 已按自检三步实测（Windows 无进程替换，改用等价临时 patch 文件写法，见下）

```text
# Windows 等价自检：临时 patch 文件 + 加载级验证
> dsh --version
0.1.0-rc.6
> dsh --profile headless --patch %TEMP%\dsh-budget-selfcheck-patch.yml --dump-config
# == C:\Users\...\dsh-budget-selfcheck-patch.yml
- id: budget
  name: dsh-budget
exit=0（加载级通过，无 FAILED）
```

- [x] 自检结果：加载级通过（row 正常挂载、dump-config 输出完整行、exit 0）。任务级（"hi" 完整对话）未执行：本机未配置 DEEPSEEK_API_KEY，无法发起模型请求；已如实标注「待测」。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：token/费用计量 + 预算上限 + 阈值告警 + 超限策略 + 碳足迹 + 延迟基准 |

## 备注

- 当前使用自有命名空间 `dsh-budget`（无 scope），获得 dsh-external 维护权限后再迁移到 `@dsh-external/*`。
- 运行状态如实填「待测」：未跑过本仓库 k8s 实测流程；本机已完成 vitest 全绿 + typecheck/typecheck:ci（对 rc.6 发布类型）+ build + verify 门禁。
