### PR TITLE
docs: 登记 dsh-draw

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -195,3 +195,4 @@
 | dsh-enhancement-suite | [Scorp1o117/dsh-enhancement-suite](https://github.com/Scorp1o117/dsh-enhancement-suite) | 四个 Scorp1o117 DSH 插件的官方总入口 + 一键安装器（list/install/update/doctor，--profile/--only/--dry-run）：零依赖，走官方 dsh plugin CLI 并安全自动挂载；npm 已发布 | 待测 |
 | dsh-passwords | [slywalker2006/dsh-passwords](https://github.com/slywalker2006/dsh-passwords) | 登录网关（密码门）：让 dsh 安全远程访问——首次配置创建主账号、多用户管理、子用户权限/配额（工作区、token、时长、上传/git）、bcrypt + 静态加密、防爆破锁定、自动 HTTPS | ✅ |
 | dsh-feishu | [PGZXB/dsh-feishu](https://github.com/PGZXB/dsh-feishu) | DeepSeek Harness 的飞书 UI：面板驱动控制台，卡内审批与提问，流式卡片，扫码一键配置 | 待测 |
+| dsh-draw | [PerryLink/dsh-draw](https://github.com/PerryLink/dsh-draw) | 统一静态图像生成路由：单一 image_generate 工具 + 标准参数，配置驱动的 OpenAI 兼容引擎路由（OpenAI Images、智谱 CogView 及任意兼容端点）与健康感知回退，工作区持久附件结果、按会话配额记账、对话内结果卡片，API key 存为凭据引用 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-draw |
| 仓库 | https://github.com/PerryLink/dsh-draw |
| **分类** | 🔌 单插件（图像生成：统一路由 + 多引擎回退） |
| 一句话说明 | 统一静态图像生成路由：单一 image_generate 工具 + 标准参数，配置驱动的 OpenAI 兼容引擎路由（OpenAI Images、智谱 CogView 及任意兼容端点）与健康感知回退，工作区持久附件结果、按会话配额记账、对话内结果卡片，API key 存为凭据引用 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-draw`（未占用 `@deepseek-ai/*` 保留命名空间；README 要求 `@dsh-external/*` scope，当前未获该 scope 授权，待获得 dsh-external 维护权限后迁移，见备注）
- [x] 仓库已打 `dsh-plugin` topic（同时含 dsh / deepseek-harness / deepseek / cordis / image-generation / openai-images / cogview / zhipu / text-to-image）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（API 开启 `maintainer_can_modify: true`）
- [x] 所有运行时依赖已声明（peerDependencies 钉 `@deepseek-ai/dsh-*@0.1.0-rc.6`、`@deepseek-ai/cordis`、`@deepseek-ai/schemastery`；typescript/tsdown 为 git 通道 prepare 构建用 dependencies）
- [x] 已按自检三步实测（Windows 无进程替换，改用等价临时 patch 文件写法，见下）

```text
# Windows 等价自检：临时 patch 文件 + 加载级验证
> dsh --version
0.1.0-rc.6
> dsh --profile headless --patch %TEMP%\dsh-draw-selfcheck-patch.yml --dump-config
# == C:\Users\...\dsh-draw-selfcheck-patch.yml
- id: dsh-draw
  name: dsh-draw
exit=0（加载级通过，无 FAILED）
```

- [x] 自检结果：加载级通过（row 正常挂载、dump-config 输出完整行、exit 0）。任务级（"hi" 完整对话）未执行：本机未配置 DEEPSEEK_API_KEY，无法发起模型请求；已如实标注「待测」。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-draw | [PerryLink/dsh-draw](https://github.com/PerryLink/dsh-draw) | 统一静态图像生成路由：多引擎路由 + 健康感知回退 + 配额记账 + 凭据引用 |

## 备注

- 当前使用自有命名空间 `dsh-draw`（无 scope），获得 dsh-external 维护权限后再迁移到 `@dsh-external/*`。
- 运行状态如实填「待测」：未跑过本仓库 k8s 实测流程；本机已完成 vitest 全绿 + typecheck/typecheck:ci（对 rc.6 发布类型）+ build + verify 门禁。
