### PR TITLE
docs: 登记 dsh-talk

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -95,6 +95,7 @@
 | dsh-smooth-stream | [Laplace-bit/dsh-smooth-stream](https://github.com/Laplace-bit/dsh-smooth-stream) | DSH Web 界面丝滑流式渲染：打字机跟随 token 到达、Markdown 边流边渲染、换行滑入、不闪烁，滚动归用户，尊重 prefers-reduced-motion | 待测 |
 
 | dsh-background-agents | [PerryLink/dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) | 交互式长会话后台 agent：官方 subagent 接缝上的可持久/可继续子 agent，Web UI 侧边栏实时进度、随时消息/打断、autoReport 进度注入、空闲归档；npm 0.5.0 已发布 | 待测 |
+| dsh-talk | [PerryLink/dsh-talk](https://github.com/PerryLink/dsh-talk) | 语音优先会话闭环：作曲器麦克风按钮 + 浏览器/本地语音转写（Web Speech、FunASR、whisper.cpp），speak 工具朗读回复（browser、edge-tts、piper），事件播报带静音开关，说话打断 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-talk |
| 仓库 | https://github.com/PerryLink/dsh-talk |
| **分类** | 🔌 单插件（语音会话：麦克风转写 + TTS 朗读） |
| 一句话说明 | 语音优先会话闭环：作曲器麦克风按钮 + 浏览器/本地语音转写（Web Speech、FunASR、whisper.cpp），speak 工具朗读回复（browser、edge-tts、piper），事件播报带静音开关，说话打断 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-talk`（未占用 `@deepseek-ai/*` 保留命名空间；README 要求 `@dsh-external/*` scope，当前未获该 scope 授权，待获得 dsh-external 维护权限后迁移，见备注）
- [x] 仓库已打 `dsh-plugin` topic（同时含 dsh / deepseek-harness / deepseek / cordis / voice / speech / tts / stt / speech-to-text / text-to-speech / microphone）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（API 开启 `maintainer_can_modify: true`）
- [x] 所有运行时依赖已声明（peerDependencies 钉 `@deepseek-ai/dsh-*@0.1.0-rc.6`、`@deepseek-ai/cordis`、`@deepseek-ai/schemastery`；typescript/tsdown 为 git 通道 prepare 构建用 dependencies）
- [x] 已按自检三步实测（Windows 无进程替换，改用等价临时 patch 文件写法，见下）

```text
# Windows 等价自检：临时 patch 文件 + 加载级验证
> dsh --version
0.1.0-rc.6
> dsh --profile headless --patch %TEMP%\dsh-talk-selfcheck-patch.yml --dump-config
# == C:\Users\...\dsh-talk-selfcheck-patch.yml
- id: talk
  name: dsh-talk
exit=0（加载级通过，无 FAILED）
```

- [x] 自检结果：加载级通过（row 正常挂载、dump-config 输出完整行、exit 0）。任务级（"hi" 完整对话）未执行：本机未配置 DEEPSEEK_API_KEY，无法发起模型请求；已如实标注「待测」。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-talk | [PerryLink/dsh-talk](https://github.com/PerryLink/dsh-talk) | 语音优先会话闭环：麦克风转写 + TTS 朗读 + 事件播报 + 说话打断 |

## 备注

- 当前使用自有命名空间 `dsh-talk`（无 scope），获得 dsh-external 维护权限后再迁移到 `@dsh-external/*`。
- 运行状态如实填「待测」：未跑过本仓库 k8s 实测流程；本机已完成 vitest 全绿 + typecheck/typecheck:ci（对 rc.6 发布类型）+ build + verify 门禁。
