### PR TITLE
docs: 登记 dsh-mmx-bridge

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -101,6 +101,7 @@
 | dsh-approval-gate | [moon09300731/dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) | 自动审批门控：Flash 预判写入/命令是否不可回补，安全操作自动批准、危险操作转人工（fail-safe） | 待测 |
 | dsh-routing-suite | [yjh051108/dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) | 注入器 × 思维模式路由套装（3300+★ 正主仓，勿与同名仿品混）：免重启运行时注入器 + 任务感知推理模式路由预设（P1-P23 实测）；injector 子目录 `dsh plugin add` 安装 | 待测（registry 插队实测） |
 | Bigfish | [turtle2209/Bigfish](https://github.com/turtle2209/Bigfish) | DeepSeek Harness 第三方桌面端：内置 Node 运行时双击即用（Top50 精选成员，registry 插队实测） | 待测（registry 插队实测） |
+| dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-mmx-bridge |
| 仓库 | https://github.com/welsione/dsh-mmx-bridge |
| **分类** | 🔌 单插件（多模态能力桥：MiniMax describe/image/video/speech/music/cover/search/quota） |
| 一句话说明 | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-mmx-bridge`（未占用 `@deepseek-ai/*` 保留命名空间；README 要求 `@dsh-external/*` scope，当前未获该 scope 授权，待获得后迁移，同 dsh-draw 先例）
- [x] 仓库已打 `dsh-plugin` topic（同时含 deepseek-harness / minimax / multimodal / image-generation / video-generation / tts / cordis 等，见 [repo topics](https://github.com/welsione/dsh-mmx-bridge)）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（本次通过 API 开启 `maintainer_can_modify: true`）
- [x] 所有运行时依赖已声明（运行时零 npm 依赖，仅依赖外部 `mmx-cli`；package.json `dependencies` 为空，无隐藏依赖）
- [x] 已在 DSH 0.1.0-rc.6（Web GUI profile）实测：工具调用正常，`/mmx-files/` 同源内嵌预览与播放器工作正常；运行级如实标「待测」，等雷达 k8s 实测流程

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖 describe/image/video/speech/music/cover/search/quota，产物同源内嵌预览/播放器 + 设置页管理卡片；零 npm 运行时依赖 |

## 备注

- 插件仓库已带 `dsh-plugin` topic 但未被雷达自动收录，故按 PR 模板人工登记。
- 运行时零 npm 依赖（仅 Node 内置模块）；工具调用依赖外部 `mmx-cli`（`npm install -g mmx-cli` + `mmx auth login`）。
- 安装方式：`dsh plugin --profile <profile> add dsh-mmx-bridge`（自动挂载 cordis.patch.yml）。
- 若分类或分区有误，随时改。
