### PR TITLE
docs: 登记 dsh-open-file

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -103,6 +103,7 @@
 | dsh-approval-gate | [moon09300731/dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) | 自动审批门控：Flash 预判写入/命令是否不可回补，安全操作自动批准、危险操作转人工（fail-safe） | 待测 |
 | dsh-routing-suite | [yjh051108/dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) | 注入器 × 思维模式路由套装（3300+★ 正主仓，勿与同名仿品混）：免重启运行时注入器 + 任务感知推理模式路由预设（P1-P23 实测）；injector 子目录 `dsh plugin add` 安装 | 待测（registry 插队实测） |
 | Bigfish | [turtle2209/Bigfish](https://github.com/turtle2209/Bigfish) | DeepSeek Harness 第三方桌面端：内置 Node 运行时双击即用（Top50 精选成员，registry 插队实测） | 待测（registry 插队实测） |
+| dsh-open-file | [Hyp6666/dsh-open-file](https://github.com/Hyp6666/dsh-open-file) | DSH Web 工作区文件附件插件：多文件选择与全页拖放，读取文本、PDF、DOCX、PPTX、XLSX、ZIP 和图片，提供英中 OCR、页面渲染及 `file_inspect` / `file_read` / `file_ocr` / `file_render` 四个可追溯工具；npm `dsh-open-file` 0.1.1 | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-open-file |
| 仓库 | https://github.com/Hyp6666/dsh-open-file |
| 一句话说明 | 为 DSH Web 增加工作区范围的任意格式文件附件、文档读取、本地 OCR 与页面渲染能力 |
| 版本 | 0.1.1（npm `dsh-open-file`） |

## 自检清单

- [x] npm 包名为公开的非 scope 包 `dsh-open-file`，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已添加 `dsh-plugin` topic
- [x] PR 允许维护者修改分支
- [x] 所有运行时依赖与 DSH peer dependencies 已在 `package.json` 声明
- [x] `npm run verify:release` 通过：typecheck、lint、29 个测试文件中的 218 项测试、生产构建和 npm 包内容校验全部成功
- [ ] 本登记 PR 未重新执行完整 DSH Web GUI 人工冒烟，因此目录中的运行级状态标记为“待测”

## 改动内容

在 `PLUGINS.md` 的“🔌 单插件”分类新增一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-open-file | [Hyp6666/dsh-open-file](https://github.com/Hyp6666/dsh-open-file) | DSH Web 工作区文件附件插件：多文件选择与全页拖放，读取文本、PDF、DOCX、PPTX、XLSX、ZIP 和图片，提供英中 OCR、页面渲染及 `file_inspect` / `file_read` / `file_ocr` / `file_render` 四个可追溯工具；npm `dsh-open-file` 0.1.1 | 待测 |

## 影响

该登记让用户可以从人工分类清单发现 `dsh-open-file`。本 PR 仅修改目录文档，不改变清单仓库的脚本或运行逻辑。

## 验证

- `git diff --check`
- 确认提交只修改 `PLUGINS.md`，新增一行
- `dsh-open-file`: `npm run verify:release`（218/218 测试通过，构建及包校验通过）
