### PR TITLE
docs: 登记 dsh-agent-team-gui

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -104,6 +104,7 @@
 | dsh-routing-suite | [yjh051108/dsh-routing-suite](https://github.com/yjh051108/dsh-routing-suite) | 注入器 × 思维模式路由套装（3300+★ 正主仓，勿与同名仿品混）：免重启运行时注入器 + 任务感知推理模式路由预设（P1-P23 实测）；injector 子目录 `dsh plugin add` 安装 | 待测（registry 插队实测） |
 | Bigfish | [turtle2209/Bigfish](https://github.com/turtle2209/Bigfish) | DeepSeek Harness 第三方桌面端：内置 Node 运行时双击即用（Top50 精选成员，registry 插队实测） | 待测（registry 插队实测） |
 | dsh-open-file | [Hyp6666/dsh-open-file](https://github.com/Hyp6666/dsh-open-file) | DSH Web 工作区文件附件插件：多文件选择与全页拖放，读取文本、PDF、DOCX、PPTX、XLSX、ZIP 和图片，提供英中 OCR、页面渲染及 `file_inspect` / `file_read` / `file_ocr` / `file_render` 四个可追溯工具；npm `dsh-open-file` 0.1.1 | 待测 |
+| dsh-agent-team-gui | [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) | 持久化多模型 Agent 小队：主 Agent 按成员特性动态编排有界 DAG，成员独立配置模型与工具策略；在 Settings/Composer 管理和选择小队，Run Center 支持追踪、重试与取消，并提供逐 Agent Token 成本洞察；v0.5.0 通过 117 Host + 62 Client 测试及 DSH rc.6 全新 Web profile 安装/浏览器冒烟 | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | `dsh-agent-team-gui` |
| 仓库 | https://github.com/toolclub/dsh-agent-team-gui |
| **分类** | 🤖 Agent 能力（`PLUGINS.md` 当前登记分区：🔌 单插件） |
| 一句话说明 | 持久化多模型 Agent 小队：主 Agent 按成员特性动态编排有界 DAG，成员可独立配置模型与工具策略，并提供 Run Center 与逐 Agent Token 成本洞察。 |
| 正式版本 | [`v0.5.0`](https://github.com/toolclub/dsh-agent-team-gui/releases/tag/v0.5.0) |

## 自检清单

- [x] `package.json` 使用公开、非 scope 包名 `dsh-agent-team-gui`；未占用 `@deepseek-ai/*`。项目未获 `dsh-external` scope 授权，遵循开发者 README 的命名空间要求，不冒用 `@dsh-external/*`。
- [x] 公开仓库已打 `dsh-plugin` topic，并提供 MIT License、安装/卸载、兼容性、权限与数据、故障排查和开发说明。
- [x] 已允许维护者修改 PR 分支（`maintainer_can_modify: true`）。
- [x] `react`、`zod` 运行时依赖以及所需 DSH peer dependencies 已在 `package.json` 显式声明。
- [x] 插件自身 CI 在 Node 22.19 与 Node 24 各通过 **117 Host + 62 Client** 测试、严格类型检查和生产构建。
- [x] DeepSeek Harness `0.1.0-rc.6` 全新 Web profile 冒烟通过：API v3、安装、首次启动、Host 重启持久化、浏览器键盘/Axe/重连/390px 布局均通过。
- [x] 精确公开提交与正式 tarball 均通过隔离 profile 安装；Release Preflight 已验证包审计、doctor、浏览器和 SHA-256。
- [ ] 本 PR 不把插件自身 CI 冒充 Radar 的 k8s 运行级判定，因此目录状态如实登记为“待测”，等待本仓库测试流程复核。

## 改动内容

仅在 `PLUGINS.md` 的“🔌 单插件”表格新增一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-agent-team-gui | [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) | 持久化多模型 Agent 小队：主 Agent 按成员特性动态编排有界 DAG，成员独立配置模型与工具策略；在 Settings/Composer 管理和选择小队，Run Center 支持追踪、重试与取消，并提供逐 Agent Token 成本洞察；v0.5.0 通过 117 Host + 62 Client 测试及 DSH rc.6 全新 Web profile 安装/浏览器冒烟 | 待测 |

## 可核验证据

- v0.5.0 Release（含编译 tarball 与 SHA256SUMS）：https://github.com/toolclub/dsh-agent-team-gui/releases/tag/v0.5.0
- 主分支 CI（提交 `6ce4453e087f15ae71e0b5b3ec4d61780c88938b`）：https://github.com/toolclub/dsh-agent-team-gui/actions/runs/32044212007
- Release Preflight：https://github.com/toolclub/dsh-agent-team-gui/actions/runs/32044608769
- 验收矩阵：https://github.com/toolclub/dsh-agent-team-gui/blob/v0.5.0/docs/v0.5-acceptance.md
- Release tarball SHA-256：`8b7bf724ea889e1ecc54cc30d1c5d3aca396dc1809b5be9b6628e29491f5d71d`

## Radar 状态说明

当前自动数据的 `data/repo-map.json` 已出现该仓库候选映射（`github:1334766747`），但当前日期快照、`PLUGINS-ALL.md` 和作者登记清单均没有展示条目。根据 README 的“提交插件”流程，本 PR 只补充作者登记清单；没有手工修改任何快照、自动生成区或 Radar 判定。

## 本 PR 验证

- `python3 scripts/classify.py "dsh-agent-team-gui" "持久化多模型 Agent 小队：主 Agent 动态编排有界 DAG，成员独立模型与工具策略，并提供运行中心和 Token 成本洞察。"` → `🤖 Agent 能力`
- `git diff --check`
- 表格列数检查通过；插件条目在 `PLUGINS.md` 中唯一
- 提交只修改 `PLUGINS.md`，新增 1 行
