### PR TITLE
docs: 登记 dsh-daily-kit

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -108,6 +108,7 @@
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |
 | dsh-subagent-cwd | [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) | dsh-subagent-tools 加按次 cwd（子代理工作目录），附两处进程内 provider 补丁；rc.6 前台/后台 cwd 实测通过 | ✅ |
 | dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体版本徽标：常驻侧边栏 Settings 行右侧，三色状态点（红=有更新/绿=最新/黄=检查中或失败），点开五态弹窗（复制更新命令/忽略/稍后/立即检查），启动 10s 首查+6h 复查；零构建、29 单测、mock-llm headless L4 实测（mainline 47f9438，证据见 [VERIFICATION.md](https://github.com/arvin-yd/dsh-update-notifier/blob/main/VERIFICATION.md)） | ✅ |
+| dsh-daily-kit | [zhouwei713/dsh-daily-kit](https://github.com/zhouwei713/dsh-daily-kit) | 日常插件集合 monorepo：16 个插件（审批门/桌面与Webhook通知/成本计量/会话导出/Ollama 本地模型/上下文水位/办公文档解析/本地文件夹索引/cron 全局调度/RSS与网页内容监控/日历/Gmail/待办/天气地点/票据识别/音视频转录）+ 4 个一键 bundle（dev-buddy/evidence-wall/inbox-zero/daily-briefing）；权限透明、读取优先、零 native 依赖，596 单测，dsh rc.6/rc.7 真实加载与 npm 安装实测通过 | ✅ |
 
 ## 🎓 技能
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-daily-kit |
| 仓库 | https://github.com/zhouwei713/dsh-daily-kit |
| **分类** | 🧰 插件集 |
| 一句话说明 | 日常插件集合 monorepo：16 个插件（审批门/通知/成本计量/会话导出/Ollama/上下文水位/文档解析/本地索引/cron 调度/RSS 与网页监控/日历/Gmail/待办/天气/票据/转录）+ 4 个一键 bundle，权限透明、读取优先、零 native 依赖 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用 `@deepseek-ai/*` 保留命名空间（使用 `dsh-daily-*` 无前缀名）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`，peer 锁 `@deepseek-ai/cordis >=4.0.1-rc.4 <4.0.2`）
- [x] 已按自检三步实测通过：

- 安装最新 dsh（rc.6 与 rc.7 均测）并加载插件：`dsh plugin --profile smoke-npm add dsh-daily-notify` / `dsh-daily-bundle-dev-buddy`，`--dump-config` 层栈逐字正确
- 真实启动：`dsh web --patch <npm 产物路径>` → HTTP 200、日志无 error（rc.6/rc.7 fail-loud 机制下服务起来即 apply 成功）

自检结果：16 个插件逐个真实挂载通过（含 4 个修复 inject 声明后复验）；npm 产物与本地构建逐文件一致；4 个 bundle 的钉版 config 全部通过各插件编译后的 Config schema 校验。已知边界：同一 profile 混装单插件与包含它的 bundle 会因重复 id 拒绝启动（已在 README 写明）。

## 改动内容

PLUGINS.md「🧰 插件集」追加一行：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-daily-kit | [zhouwei713/dsh-daily-kit](https://github.com/zhouwei713/dsh-daily-kit) | 日常插件集合 monorepo：16 插件 + 4 一键 bundle；596 单测、rc.6/rc.7 真实加载与 npm 安装实测、npm 可装 |

## 备注

- 集合亮点：每个插件 README 含「权限透明」章节（读写位置/网络域名/凭证/确认点/日志内容逐条交代）；外部服务插件（mail/calendar）默认只读、写操作门控；文档解析带引用位置回传（PDF 页码/Sheet!Cell/slide 号/标题路径）。
- 596 个 node:test 单测；每日兼容 CI（.github/workflows/compat.yml）对 dsh 最新 rc 跑类型检查+全量单测。
