### PR TITLE
docs: 登记 CiteCiter

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -30,6 +30,7 @@
 | dsh-genui | [omdsh-dev/dsh-genui](https://github.com/omdsh-dev/dsh-genui) | GenUI 内联交互组件：dsh-ui fence 渲染图表/表单/测验/3D 场景，带 action 事件环 | ✅ |
 | dsh-annotation | [omdsh-dev/dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | DSH Web 选中批注插件：选文字→批注→回车随消息发送，回复按 Annotation N 逐条对照（可悬浮芯片） | ✅ |
 | dsh-ui-quote-selection | [nekogpt/dsh-ui-quote-selection](https://github.com/nekogpt/dsh-ui-quote-selection) | 在 DSH Web 中选中文字，一键引用到输入框；发送问题时自动附上完整原文 | ✅ |
+| CiteCiter | [kirkchinese/CiteCiter](https://github.com/kirkchinese/CiteCiter) | 在 DSH Web 中选中已完成的助手回复，右键 `Citer!` 后从真实会话边界创建只读子会话，并在 details 侧栏流式解释；不写入父会话日志，支持 Markdown、代码、KaTeX、安全 SVG 与无网络 HTML 预览；npm `@kirkchinese/dsh-citeciter` 0.1.1，17 项测试及真实 registry 安装、浏览器 smoke 均通过 | 待测 |
 | dsh-security-scan | [ben7am1n/dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | Secret & dangerous-pattern scanner — API keys/tokens/private keys redacted; ignore lists; zero deps | ✅ |
 | dsh-email | [STARDUSTLC666/dsh-email](https://github.com/STARDUSTLC666/dsh-email) | 邮件工具插件：IMAP/SMTP 收/发/搜/列文件夹/附件下载（email_list/read/search/send/folders/attachment），内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，支持多账号与连接复用，发信默认走审批门；纯 Node 全平台 | 待测 |
 | dsh-calendar | [STARDUSTLC666/dsh-calendar](https://github.com/STARDUSTLC666/dsh-calendar) | CalDAV 日历插件：查/建/改/删/搜日程（calendar_list/create/update/delete/search），Google/iCloud/Nextcloud/自定义端点，应用专用密码 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | CiteCiter |
| 仓库 | https://github.com/kirkchinese/CiteCiter |
| **分类** | 🔌 Web UI 增强 |
| 一句话说明 | 在 DSH Web 中选中已完成的助手回复，基于当时的真实会话上下文在只读子会话中解释，并流式呈现在 details 侧栏。 |

## 自检清单

- [x] npm 包使用维护者有权控制的个人 scope：`@kirkchinese/dsh-citeciter`
- [x] 仓库已添加 `dsh-plugin` topic
- [x] `package.json` 声明 `dsh.bundle.patch` 与全部运行时 peer dependencies
- [x] 当前 npm latest 为 `0.1.1`，可通过 `dsh plugin --profile web add @kirkchinese/dsh-citeciter@0.1.1` 安装并自动挂载
- [x] 包级 typecheck、build 与 17 项测试通过
- [x] 公共 registry 全新 profile 安装及浏览器 smoke 通过；父会话日志 size/mtime 保持不变
- [x] PR 默认允许维护者编辑

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| CiteCiter | [kirkchinese/CiteCiter](https://github.com/kirkchinese/CiteCiter) | 在 DSH Web 中选中已完成的助手回复，右键 `Citer!` 后从真实会话边界创建只读子会话，并在 details 侧栏流式解释；不写入父会话日志，支持 Markdown、代码、KaTeX、安全 SVG 与无网络 HTML 预览；npm `@kirkchinese/dsh-citeciter` 0.1.1，17 项测试及真实 registry 安装、浏览器 smoke 均通过 | 待测 |

## 备注

CiteCiter 当前仍处于早期开发阶段，支持基准为 DSH `0.1.0-rc.6`。npm `0.1.0` 因遗漏 bundle 元数据已弃用；`0.1.1` 已修复并经过真实安装验证。
