### PR TITLE
docs: 登记 dsh-simple-wiki-memory

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -205,3 +205,4 @@
 | dsh-library | [PerryLink/dsh-library](https://github.com/PerryLink/dsh-library) | 本地优先文档知识库：library_add/remove/list、语义+关键词混合 library_search（多样性重排、相关性过滤、避免 lost-in-the-middle）、引用感知注入与 library_cite_check/diagnose，SQLite 索引 + 本地嵌入，零模型下载 | 待测 |
 | dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 | 待测 |
 | dsh-defend | [PerryLink/dsh-defend](https://github.com/PerryLink/dsh-defend) | 注入/越狱/密钥泄露检测 + 危险删除门禁：Aho-Corasick 引擎在用户消息、工具参数、工具结果三处按 allow/ask/block 拦截（脱敏 defend/detection 审计事件、defend_report 工具、/defend 命令），并拒绝工作区外的递归删除命令 | 待测 |
+| dsh-simple-wiki-memory | [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) | 简易 Wiki 持久记忆（DSWM）：一个索引文档自动注入 + 每主题一个 md 文件按需读取，省 token 轻量无压力；pending 准入→确认晋升→archive 归档三区 + memory-log 审计 + git 自动备份；纯 Markdown 所见即所得，跨 harness 共享 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-simple-wiki-memory |
| 仓库 | https://github.com/rainow/dsh-simple-wiki-memory |
| **分类** | 🧠 记忆增强 |
| 一句话说明 | 简易 Wiki 持久记忆：一个索引文档自动注入 + 每主题一个 md 文件按需读取；pending 准入→晋升→archive 归档 + memory-log 审计 + git 自动备份，纯 Markdown 跨 harness 共享 |

## 自检清单

- [x] package.json `name` 非空（`dsh-simple-wiki-memory`，无 scope——与 PLUGINS.md 现有多个无 scope 插件一致）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已勾选 Allow edits from maintainers
- [x] 运行时依赖已声明（`peerDependencies`：@deepseek-ai/cordis、dsh-session、dsh-llm）
- [x] 语法校验：`node --check lib/index.js` 通过；同步层冒烟测试通过（临时 HOME 模拟建目录/git init/用户条目保留/commit）
- [ ] 加载级实测：本机无 headless profile，未做 `dsh --profile headless` 加载测试（运行时依赖 @deepseek-ai/dsh-llm 未安装）；功能已在本机 web profile 通过 AGENTS.md 规则验证（pending 汇报/晋升/归档全流程实测）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-simple-wiki-memory | [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) | 简易 Wiki 持久记忆（DSWM）：一个索引文档自动注入 + 每主题一个 md 文件按需读取，省 token 轻量无压力；pending 准入→确认晋升→archive 归档三区 + memory-log 审计 + git 自动备份；纯 Markdown 所见即所得，跨 harness 共享 |

## 备注

- 依赖 DSH 原生 `dsh-agent-instructions` 机制（dsh-base 默认启用）
- 分类器验证：`python3 scripts/classify.py` → 🧠 记忆增强（命中 memory）