### PR TITLE
docs(plugins): register dsh-ssh and dsh-mcp-list

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -107,6 +107,7 @@
 | dsh-agent-team-gui | [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) | 持久化多模型 Agent 小队：主 Agent 按成员特性动态编排有界 DAG，成员独立配置模型与工具策略；在 Settings/Composer 管理和选择小队，Run Center 支持追踪、重试与取消，并提供逐 Agent Token 成本洞察；v0.5.0 通过 117 Host + 62 Client 测试及 DSH rc.6 全新 Web profile 安装/浏览器冒烟 | 待测 |
 | dsh-ssh | [dmz2922990/dsh-ssh](https://github.com/dmz2922990/dsh-ssh) | SSH 主机管理 + 远程执行：ssh_host_list/add/update/remove/ssh_bash 五工具，主机台账持久化到 ~/.dsh/ssh-hosts.json，支持 agent/key/password 三种认证（password 走 SSH_ASKPASS，沙箱可用）；提供 Agent 预设与 Cordis 插件两种形态 | 待测 |
 | dsh-mcp-list | [dmz2922990/dsh-mcp-list](https://github.com/dmz2922990/dsh-mcp-list) | 设置面板新增 MCP 页：按服务器分组列出全部已挂载 MCP 服务器与工具，扫描最近会话统计各工具调用次数，一键在系统编辑器打开 cordis.patch.yml 的 MCP 配置 | 待测 |
+| dsh-thinkmeter | [dmz2922990/dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter) | Think 思考行 Token 计量表：把聊天视图流式 Think 预览替换为实时 token 数显示（Thinking ≈ N tokens），落定时精确取 usage.reasoningTokens、缺失时启发式估算，点击可展开/收起完整思考文本（web client 插件，dsh.bundle 一键安装） | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 ## 🧰 插件集
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -105,6 +105,8 @@
 | Bigfish | [turtle2209/Bigfish](https://github.com/turtle2209/Bigfish) | DeepSeek Harness 第三方桌面端：内置 Node 运行时双击即用（Top50 精选成员，registry 插队实测） | 待测（registry 插队实测） |
 | dsh-open-file | [Hyp6666/dsh-open-file](https://github.com/Hyp6666/dsh-open-file) | DSH Web 工作区文件附件插件：多文件选择与全页拖放，读取文本、PDF、DOCX、PPTX、XLSX、ZIP 和图片，提供英中 OCR、页面渲染及 `file_inspect` / `file_read` / `file_ocr` / `file_render` 四个可追溯工具；npm `dsh-open-file` 0.1.1 | 待测 |
 | dsh-agent-team-gui | [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) | 持久化多模型 Agent 小队：主 Agent 按成员特性动态编排有界 DAG，成员独立配置模型与工具策略；在 Settings/Composer 管理和选择小队，Run Center 支持追踪、重试与取消，并提供逐 Agent Token 成本洞察；v0.5.0 通过 117 Host + 62 Client 测试及 DSH rc.6 全新 Web profile 安装/浏览器冒烟 | 待测 |
+| dsh-ssh | [dmz2922990/dsh-ssh](https://github.com/dmz2922990/dsh-ssh) | SSH 主机管理 + 远程执行：ssh_host_list/add/update/remove/ssh_bash 五工具，主机台账持久化到 ~/.dsh/ssh-hosts.json，支持 agent/key/password 三种认证（password 走 SSH_ASKPASS，沙箱可用）；提供 Agent 预设与 Cordis 插件两种形态 | 待测 |
+| dsh-mcp-list | [dmz2922990/dsh-mcp-list](https://github.com/dmz2922990/dsh-mcp-list) | 设置面板新增 MCP 页：按服务器分组列出全部已挂载 MCP 服务器与工具，扫描最近会话统计各工具调用次数，一键在系统编辑器打开 cordis.patch.yml 的 MCP 配置 | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
## 登记插件

按「给插件开发者 → 提交插件」流程在 PLUGINS.md 的 🔌 单插件 分类追加三个插件：

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-ssh | [dmz2922990/dsh-ssh](https://github.com/dmz2922990/dsh-ssh) | SSH 主机管理 + 远程执行（ssh_host_add/list/update/remove/ssh_bash），台账持久化到 ~/.dsh/ssh-hosts.json，支持 agent/key/password 三种认证 |
| dsh-mcp-list | [dmz2922990/dsh-mcp-list](https://github.com/dmz2922990/dsh-mcp-list) | 设置面板新增 MCP 页：分组列出已挂载 MCP 服务器与工具、调用次数统计、一键打开 cordis.patch.yml 配置 |
| dsh-thinkmeter | [dmz2922990/dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter) | Think 思考行实时 Token 计量：将流式思考预览替换为 token 数显示，精确取 usage.reasoningTokens、缺失时启发式估算（web client 插件） |

## 自检（对照最低收录条件）

- [x] 仓库公开可访问，已添加 `dsh-plugin` topic
- [x] 根目录存在合法 package.json 与非空 name
- [x] 提供 dsh 集成入口
- [x] README 说明功能、安装与卸载方式
- [x] 运行级状态如实标注为「待测」（等待雷达 k8s 实测）

运行级结果以雷达自动验证为准。