### PR TITLE
docs: 登记 dsh-experts

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -115,6 +115,7 @@
 | dsh-trading-toolkit | [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) | A股+美股行情工具箱：实时行情/OHLCV K线/ADX 三状态信号/回测预览，东方财富免 Key 直连，只读永不下单 | ? |
 | dsh-univer-office | [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | Univer 办公插件：在 DSH 中创建/编辑/检查/交付表格、文档、演示文稿、多维表格和画布，支持 xlsx/docx/pptx 导入导出、实时预览与 worktree 审阅；npm `dsh-univer-office` 0.2.5 | 待测 |
 | dsh-prompt-optimizer | [Y1X1n/dsh-prompt-optimizer](https://github.com/Y1X1n/dsh-prompt-optimizer) | 发送栏「优化」按钮：跟随会话当前模型（可固定，支持回退路由自动 failover）一键分析并改写提示词草稿，SSE 流式逐段上屏；输入卡上方 dock 面板展示五维诊断与优化稿，可替换/撤回/复制/重试；设置页折叠卡十项配置（快速模式、推理钳档、Token 上限自适应等）；40 例自动化测试，rc.7 真实 profile 端到端实测 | 待测 |
+| dsh-experts | [fuchao2pku/dsh-experts](https://github.com/fuchao2pku/dsh-experts) | DSH 设置页内置「专家市场」：浏览/搜索社区专家与专家团、查看详情并复制到输入框；默认消费 awesome-dsh-experts 目录（7 个种子专家/团），rc.6 web profile 实测 0 加载错误、27 测试全绿 | ✅ |
 | dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
## 简介
[dsh-experts](https://github.com/fuchao2pku/dsh-experts) 是一个 out-of-tree DSH bundle，把 [Awesome DSH Experts](https://github.com/fuchao2pku/awesome-dsh-experts) 社区专家 / 专家团目录接入 DSH Web 界面（设置页「专家市场」+ 聊天框一键引入对话）。

## 目录规模（最新）
- **45 个条目**：25 个单专家 + 20 个专家团
- 覆盖编程、写作、设计、数据、运维、法务、教育、多模态、通用管理等分类
- 专家团含真实成员交叉引用，0 断链

## 在线站点（GitHub Pages）
https://fuchao2pku.github.io/awesome-dsh-experts/
- 暗黑模式专家市场：精选场景、专家/专家团 Tab、分类筛选、搜索、排序
- 首页含「如何在 DSH 中一键使用」使用指南

## 安装
```bash
dsh plugin --profile web add https://github.com/fuchao2pku/dsh-experts.git
```
安装后在设置页「专家市场」浏览，点击「引入对话」即可把专家提示注入聊天框；或在聊天框直接输入 `@expert <id>`。

## 兼容性
- deepseek-harness 0.1.0-rc.6、web profile
- 浏览器只调同源 `/api/expert-marketplace`；host(Node) 拉取 companion repo 的 `catalog.json`，目录视为不可信、逐条 schema 校验、绝不执行代码
