### PR TITLE
docs: 登记 dsh-session-tabs

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -17,6 +17,7 @@
 | dsh-plugin-guard | [lxzy-7/dsh-plugin-guard](https://github.com/lxzy-7/dsh-plugin-guard) | 插件安装安全网：装/卸/开关插件前自动快照备份，启动健康检查失败自动回退最后良好快照并重试一次，设置>备份管理面板 + 双击一键回退脚本，事故报告自动触发 Agent 分析；零运行时依赖，引擎冒烟测试 + 三种安装布局实测通过 | ✅ |
 | dsh-office | [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) | 办公室工作区/会话仪表盘：悬浮 6 列精灵面板，可视化工作区、会话、token 用量与子代理（web bundle） | ✅ |
 | deepseek-heartflow | [yun520-1/deepseek-heartflow](https://github.com/yun520-1/deepseek-heartflow) | 心虫（AGI 第1层辨别门禁）：47 维纯规则文本判别 heartflow_check 工具 + tools/post-execute 自动输出监督（block 拦截 / rewrite 提醒），引擎缺失 fail-closed；dsh.bundle manifest 可安装 | ✅ |
+| dsh-session-tabs | [licat2023/dsh-session-tabs](https://github.com/licat2023/dsh-session-tabs) | 浏览器式会话标签页：顶部标签条从侧边栏右缘开始（不挤占侧边栏），点击切换/关闭/新建、中键关标签与侧边栏后台打开、鼠标侧键会话历史导航、运行状态点；纯客户端零网络零持久化 | 待测 |
 | dsh-repo-context | [qing3a/dsh-repo-context](https://github.com/qing3a/dsh-repo-context) | 把 git 状态与仓库规范动态注入 system prompt（section/context/variable，官方 system-prompt 缝隙插件）；dsh-plugin-verify 0.1.2 实测 7/7 waterfall + 工具真实执行（R3 isError:false） | ✅ |
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
 | dsh-spend | [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | Token 用量统计与预计费用：右下角悬浮窗，按模型/按天/按会话多维聚合，内置供应商知识库自动识别计费计划（web bundle） | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
| --- | --- |
| 插件名 | dsh-session-tabs |
| 仓库 | https://github.com/licat2023/dsh-session-tabs |
| 分类 | 🔌 单插件（Web UI 增强） |
| 一句话说明 | 浏览器式会话标签页（侧边栏旁顶部标签条，不挤占侧边栏）：点击切换/关闭/新建、中键关闭与后台打开、鼠标侧键会话历史导航、运行状态点，纯客户端零网络零持久化 |

## 自检清单

- [x] package.json `name` 使用裸名 `dsh-session-tabs`（与 repo 名一致，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已勾选 **Allow edits from maintainers**（已在 fork Settings → General 开启同项）
- [x] 所有运行时依赖已声明（`peerDependencies`：`react ^18.2.0`、`@deepseek-ai/cordis ^4.0.1`）
- [x] 已按自检三步实测通过：

```sh
# 实测方式 1（npm 发行版 0.1.0-rc.6，官方命令）：
npm install @deepseek-ai/dsh@0.1.0-rc.6
npx @deepseek-ai/dsh plugin --profile web add ./dsh-session-tabs
npx @deepseek-ai/dsh web --port 3090
# 浏览器实测（2026-08-18）：标签创建/标题实时更新/点击切换/中键关闭激活与非激活标签/
# 关闭全部跳首页/侧键 back 恢复最近历史/forward 终结性无响应 —— 全部通过

# 实测方式 2（mainline 0.1.0-rc.7 源码）：
dsh plugin --profile web add ./dsh-session-tabs
# 页面刷新自动挂载 shell.overlay 槽位，全功能链路实测通过（2026-08-18，0.1.0-rc.7 @ 99f6f02fec）
```

## 改动内容

| 插件 | 仓库 | 说明 |
| --- | --- | --- |
| dsh-session-tabs | [licat2023/dsh-session-tabs](https://github.com/licat2023/dsh-session-tabs) | 浏览器式会话标签页：顶部标签条从侧边栏右缘开始（不挤占侧边栏），点击切换/关闭/新建、中键关标签与侧边栏后台打开、鼠标侧键会话历史导航、运行状态点；纯客户端零网络零持久化 | 待测 |

## 备注

- `PLUGINS.md` 已在 **🔌 单插件** 分类表追加一行（见改动内容表）；
- 实测版本：`0.1.0-rc.6`（npm 发行版，官方命令真机验证）与 `0.1.0-rc.7`（mainline 源码，全量功能实测）；理论上支持 `0.1.0-rc.6` 及之后的所有版本（接口均为自 `0.1.0-rc.6` 以来稳定的公开接口：槽位标准 prop + sessions/workspaces 公开方法）；
- 运行级状态留「待测」，等待雷达容器实测判定。
