### PR TITLE
docs: 登记 dsh-prompt-optimizer

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -110,6 +110,7 @@
 | dsh-thinkmeter | [dmz2922990/dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter) | Think 思考行 Token 计量表：把聊天视图流式 Think 预览替换为实时 token 数显示（Thinking ≈ N tokens），落定时精确取 usage.reasoningTokens、缺失时启发式估算，点击可展开/收起完整思考文本（web client 插件，dsh.bundle 一键安装） | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 | dsh-trading-toolkit | [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) | A股+美股行情工具箱：实时行情/OHLCV K线/ADX 三状态信号/回测预览，东方财富免 Key 直连，只读永不下单 | ? |
+| dsh-prompt-optimizer | [Y1X1n/dsh-prompt-optimizer](https://github.com/Y1X1n/dsh-prompt-optimizer) | 发送栏「优化」按钮(host+client)：复用会话当前模型一键分析并改写输入框中的提示词草稿，输入卡上方整行面板展示分析诊断与优化稿，可一键替换；设置页可固定模型/语言/Token 上限，截断有提示；真实 profile 实测加载/路由/端到端调用通过 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-prompt-optimizer |
| 仓库 | https://github.com/Y1X1n/dsh-prompt-optimizer |
| **分类** | 🔌 Web UI 增强(规则关键词:输入框 / 面板 / dock;本机无 python3,未跑 classify.py,按 docs/CATALOGING.md 人工比对) |
| 一句话说明 | 发送栏「优化」按钮:复用会话当前模型一键分析并改写输入框中的提示词草稿,输入卡上方整行面板展示分析诊断与优化稿,可一键替换;设置页可固定模型/语言/Token 上限 |

## 自检清单(提交前逐项确认)

- [x] package.json `name` 未占用保留命名空间(独立包名 `dsh-prompt-optimizer`,非 `@deepseek-ai/*`,也未冒用 `@dsh-external/*`)
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**(fork 提 PR 默认开启)
- [x] 所有运行时依赖已声明(`@deepseek-ai/dsh-settings`、`@deepseek-ai/schemastery` 在 `dependencies`;react 等客户端依赖由 Harness 页面运行时以外部模块提供)
- [x] 已实测通过(见下)

自检结果:dsh 0.1.0-rc.7 + Windows,真实 web profile 安装后验证——启动日志 `[dsh-prompt-optimizer] loaded`;插件路由 `POST /dsh-prompt-optimizer/optimize` 的 405/400/409/502 各路径行为正确;客户端 bundle 被收录进 `window.__DSH_BOOT__` 并可经 `/plugins/dsh-prompt-optimizer/client.js` 访问;端到端用 DeepSeek 官方路由真实完成一次「分析 + 改写」;`node test/smoke.mjs` 9 项 Host 用例(含空配置回落、max-tokens 截断)全过。

## 改动内容

`PLUGINS.md`「🔌 单插件」表追加一行:

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-prompt-optimizer | [Y1X1n/dsh-prompt-optimizer](https://github.com/Y1X1n/dsh-prompt-optimizer) | 发送栏「优化」按钮(host+client):复用会话当前模型一键分析并改写输入框中的提示词草稿,输入卡上方整行面板展示分析诊断与优化稿,可一键替换;设置页可固定模型/语言/Token 上限,截断有提示;真实 profile 实测加载/路由/端到端调用通过 | 待测 |

## 备注

- 提供 Release 预构建 tarball(免 `allowBuilds` 授权):https://github.com/Y1X1n/dsh-prompt-optimizer/releases/latest/download/dsh-prompt-optimizer-0.1.0.tgz
- 兼容基线:`@deepseek-ai/*` 0.1.0-rc.7;客户端双半侧(host 路由 + web bundle),对 HTTP 服务名漂移(`httpServer`/`webServer`)做了双名兼容。
