### PR TITLE
docs: 登记 dsh-desk-pet

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -116,6 +116,7 @@
 | dsh-univer-office | [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | Univer 办公插件：在 DSH 中创建/编辑/检查/交付表格、文档、演示文稿、多维表格和画布，支持 xlsx/docx/pptx 导入导出、实时预览与 worktree 审阅；npm `dsh-univer-office` 0.2.5 | 待测 |
 | dsh-prompt-optimizer | [Y1X1n/dsh-prompt-optimizer](https://github.com/Y1X1n/dsh-prompt-optimizer) | 发送栏「优化」按钮：跟随会话当前模型（可固定，支持回退路由自动 failover）一键分析并改写提示词草稿，SSE 流式逐段上屏；输入卡上方 dock 面板展示五维诊断与优化稿，可替换/撤回/复制/重试；设置页折叠卡十项配置（快速模式、推理钳档、Token 上限自适应等）；40 例自动化测试，rc.7 真实 profile 端到端实测 | 待测 |
 | dsh-experts | [fuchao2pku/dsh-experts](https://github.com/fuchao2pku/dsh-experts) | DSH 设置页内置「专家市场」：浏览/搜索社区专家与专家团、查看详情并复制到输入框；默认消费 awesome-dsh-experts 目录（7 个种子专家/团），rc.6 web profile 实测 0 加载错误、27 测试全绿 | ✅ |
+| dsh-desk-pet | [anneheartrecord/dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) | macOS 桌宠：真的 AppKit 置顶窗口而不是页面里的挂件，全屏 Space 也盖得住；六种状态跟着本地 DSH 走（空闲／干活／等你确认／报错／刚跑完／打盹），原生右键菜单含免打扰与会话清单；自带的 skill 用你自己的画图工具和额度把一张照片扩成整套十八个姿势的皮肤，装在包外，升级不会删。跑系统自带的 Python 与 ctypes，零运行时依赖，不用 Electron。**仅 macOS** | 待测 |
 | dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-desk-pet |
| 仓库 | https://github.com/anneheartrecord/dsh-desk-pet |
| **分类** | 🔌 单插件 |
| 一句话说明 | macOS 桌宠：真的 AppKit 置顶窗口而不是页面挂件，六种状态跟着本地 DSH 走，原生右键菜单；自带的 skill 用你自己的画图工具把一张照片扩成整套十八个姿势的皮肤。零依赖，跑系统自带的 Python 与 ctypes。 |

只往 `PLUGINS.md` 的「🔌 单插件」表尾追加了一行，没有动别的条目，`README.md` 未改。

## ⚠️ 请先看这一条：你们的运行级测试大概率会判它不兼容

这个插件**只支持 macOS**，渲染层是 ctypes 直调 AppKit，没有 Windows / Linux 实现。你们的运行级口径是「k8s 容器实测」，那是 Linux 容器——它在里面一定起不来窗口。

所以我把「运行级」填的是 `待测`，并且想提前说明：如果那一轮判成「运行级不兼容」，那不是依赖装不上或缺内部包，是平台本身不在支持范围内，和你们四档表里「不代表永远不可用；作者可能已在新版本修复」的语义也不一样。要不要为这种情况单列一档，或者干脆在说明里标注平台，由你们定——我在说明末尾已经写了 **仅 macOS**。

插件本身在 macOS 上是实测可用的：261 个单元测试 + 一个逐像素素材闸 + 一个 Node 侧插件冒烟测试，`dsh plugin --profile web add deepseek-desk-pet` 装完 `dsh web` 直接出宠物。

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic（另有 `deepseek-harness` / `dsh` / `desktop-pet`）
- [x] 根目录有合法 `package.json`，`name` 非空，声明了 `dsh.bundle`（`./cordis.patch.yml`）
- [x] 所有运行时依赖已声明——准确说是**一个都没有**，`dependencies` 为空：跑系统自带的 `/usr/bin/python3`，靠标准库 ctypes 调 AppKit，连 ffmpeg 都不需要
- [x] 有 LICENSE（MIT）
- [x] README 说明做什么、怎么装、怎么卸、最小使用示例；中英双语
- [x] 已在 PR 页面允许维护者编辑
- [ ] **package.json `name` 使用 `@dsh-external/*` scope**——没有用，这一条我不能勾。npm 包名是 `deepseek-desk-pet`（无 scope，我自己的命名空间，未占用任何保留前缀）。仓库叫 `dsh-desk-pet` 而包叫 `deepseek-desk-pet`，是因为 npm 认为 `dsh-desk-pet` 与一个无关的 `dsh-deskpet` 归一化后同名，拒绝发布。你们的最低条件写的是「包名应使用你有权控制的命名空间」，这一点是满足的；如果 `@dsh-external/*` 是硬性要求而不是建议，请告诉我，我按要求改。
