### PR TITLE
docs: 登记 dsh-prompt-optimizer

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -110,6 +110,7 @@
 | dsh-thinkmeter | [dmz2922990/dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter) | Think 思考行 Token 计量表：把聊天视图流式 Think 预览替换为实时 token 数显示（Thinking ≈ N tokens），落定时精确取 usage.reasoningTokens、缺失时启发式估算，点击可展开/收起完整思考文本（web client 插件，dsh.bundle 一键安装） | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 | dsh-trading-toolkit | [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) | A股+美股行情工具箱：实时行情/OHLCV K线/ADX 三状态信号/回测预览，东方财富免 Key 直连，只读永不下单 | ? |
+| dsh-prompt-optimizer | [winditer/dsh-prompt-optimizer](https://github.com/winditer/dsh-prompt-optimizer) | 输入框 prompt 优化：✨ 按钮/Alt+O 一键把草稿润色为清晰结构化 prompt；默认零配置复用当前会话模型（SSE 真流式 + reasoning 先出），也可自配任意 OpenAI 兼容端点；双语 UI；npm 已发布 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-prompt-optimizer |
| 仓库 | https://github.com/winditer/dsh-prompt-optimizer |
| **分类** | 🔌 Web UI 增强（官方 classify.py 预归类；PLUGINS.md 单插件区） |
| 一句话说明 | 输入框 prompt 优化：一键把草稿润色为清晰结构化 prompt；零配置复用当前会话模型（SSE 真流式 + reasoning 先出），也可自配 OpenAI 兼容端点 |

## 自检清单

- [x] package.json `name` 使用自有命名空间（`dsh-prompt-optimizer`，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic（另加 `dsh-prompt-optimizer`）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（fork 已开放，见下方备注）
- [x] 所有运行时依赖已声明（`dependencies` 为空——零运行时依赖，宿主服务经 `cordis.patch.yml` 声明）
- [x] 已按自检三步实测通过：`dsh plugin --profile desktop add dsh-prompt-optimizer`（npm 已发布 2.0.0），desktop 实测 ✨ 优化 → SSE 流式 + reasoning 先出 + 替换草稿正常

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-prompt-optimizer | https://github.com/winditer/dsh-prompt-optimizer | 输入框 prompt 优化：✨ 按钮/Alt+O 一键润色草稿；零配置会话模型（SSE 真流式 + reasoning 先出）；可自配 OpenAI 兼容端点 |

## 备注

fork：https://github.com/winditer/awesome-dsh-plugins（维护者编辑权限已在 fork 的 Settings → General 开启，可持续 allow edits from maintainers）