### PR TITLE
docs: 登记 dsh-prompt-optimizer(v2,替代 #249)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -114,6 +114,7 @@
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 | dsh-trading-toolkit | [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) | A股+美股行情工具箱：实时行情/OHLCV K线/ADX 三状态信号/回测预览，东方财富免 Key 直连，只读永不下单 | ? |
 | dsh-univer-office | [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | Univer 办公插件：在 DSH 中创建/编辑/检查/交付表格、文档、演示文稿、多维表格和画布，支持 xlsx/docx/pptx 导入导出、实时预览与 worktree 审阅；npm `dsh-univer-office` 0.2.5 | 待测 |
+| dsh-prompt-optimizer | [Y1X1n/dsh-prompt-optimizer](https://github.com/Y1X1n/dsh-prompt-optimizer) | 发送栏「优化」按钮：跟随会话当前模型（可固定，支持回退路由自动 failover）一键分析并改写提示词草稿，SSE 流式逐段上屏；输入卡上方 dock 面板展示五维诊断与优化稿，可替换/撤回/复制/重试；设置页折叠卡十项配置（快速模式、推理钳档、Token 上限自适应等）；40 例自动化测试，rc.7 真实 profile 端到端实测 | 待测 |
 | dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
重新提交,替代已撤回的 #249——插件自首次登记后大幅演进,条目描述全面更新。

## 插件简介

[dsh-prompt-optimizer](https://github.com/Y1X1n/dsh-prompt-optimizer):DeepSeek Harness 提示词优化插件(host + client 双半侧)。发送栏「优化」按钮一键分析并改写输入框中的提示词草稿。

## 当前功能(v0.3.2)

- 跟随会话当前模型(每次点击实时查询),可在设置页固定;支持回退模型自动 failover
- **SSE 流式输出**:分析诊断(五维度)与优化稿逐段上屏,不做整段等待
- 结果面板在输入卡上方整行(不遮挡输入框),可替换(可撤回)/复制/重新优化,Esc 取消,按会话隔离
- 设置页折叠卡:快速模式(仅优化)、推理强度钳档、Token 上限自适应长草稿、温度/超时等十项
- 内置模型连通性测试(32 token / 20s 封顶探活)
- 40 例自动化测试(smoke 24 + prompt 7 + controller 9),rc.7 真实 profile 端到端实测通过

安装:`dsh plugin --profile web add <release tarball>`,Release 有预构建包与永久直链。

条目插入在「🔌 单插件」表尾,单行新增,无其他文件改动。