### PR TITLE
docs: 登记 dsh-plugins（MkaliezZ 插件族）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -11,6 +11,9 @@
 
 | 插件 | 仓库 | 说明 | 运行级 |
 |---|---|---|---|
+| dsh-agentfuse-plugin | [MkaliezZ/dsh-agentfuse-plugin](https://github.com/MkaliezZ/dsh-agentfuse-plugin) | 确定性 fail-closed 工具调用授权门：allow/block/ask 策略门 + 审批链延后 + agentfuse-evidence-schema 证据；配 dsh-policy-test 闭环回归；已获本雷达运行级 [可用] 判定 | ✅ |
+| dsh-evidence-task-board | [MkaliezZ/dsh-evidence-task-board](https://github.com/MkaliezZ/dsh-evidence-task-board) | 持久化确定性任务状态原语（创建/状态/证据转移）；npm 包 @mkaliezz/dsh-task-board | 待测 |
+| dsh-test-normalizer | [MkaliezZ/dsh-test-normalizer](https://github.com/MkaliezZ/dsh-test-normalizer) | pytest / Vitest / Jest / Cargo 测试结果归一化为稳定结构；npm 包 @mkaliezz/dsh-test-runner | 待测 |
 | dsh-plugin-guard | [lxzy-7/dsh-plugin-guard](https://github.com/lxzy-7/dsh-plugin-guard) | 插件安装安全网：装/卸/开关插件前自动快照备份，启动健康检查失败自动回退最后良好快照并重试一次，设置>备份管理面板 + 双击一键回退脚本，事故报告自动触发 Agent 分析；零运行时依赖，引擎冒烟测试 + 三种安装布局实测通过 | ✅ |
 | dsh-office | [Fayelin12/dsh-office](https://github.com/Fayelin12/dsh-office) | 办公室工作区/会话仪表盘：悬浮 6 列精灵面板，可视化工作区、会话、token 用量与子代理（web bundle） | ✅ |
 | deepseek-heartflow | [yun520-1/deepseek-heartflow](https://github.com/yun520-1/deepseek-heartflow) | 心虫（AGI 第1层辨别门禁）：47 维纯规则文本判别 heartflow_check 工具 + tools/post-execute 自动输出监督（block 拦截 / rewrite 提醒），引擎缺失 fail-closed；dsh.bundle manifest 可安装 | ✅ |
@@ -114,6 +117,7 @@
 
 | 插件 | 仓库 | 说明 | 运行级 |
 |---|---|---|---|
+| dsh-plugins | [MkaliezZ/dsh-plugins](https://github.com/MkaliezZ/dsh-plugins) | DSH 插件家族索引：16 个插件（fail-closed 授权安全线 / 策略测试与诊断 / 工作区生产力 / 运行时基础设施），统一 dsh-plugin topic | 待测 |
 | dsh-subagent-tools | [lynx-gt/dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) | 子代理委派按次覆盖 model/provider/persona/toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）；rc.6 headless+web 实测通过 | ✅ |
 | dsh-subagent-cwd | [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) | dsh-subagent-tools 加按次 cwd（子代理工作目录），附两处进程内 provider 补丁；rc.6 前台/后台 cwd 实测通过 | ✅ |
 | dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体版本徽标：常驻侧边栏 Settings 行右侧，三色状态点（红=有更新/绿=最新/黄=检查中或失败），点开五态弹窗（复制更新命令/忽略/稍后/立即检查），启动 10s 首查+6h 复查；零构建、29 单测、mock-llm headless L4 实测（mainline 47f9438，证据见 [VERIFICATION.md](https://github.com/arvin-yd/dsh-update-notifier/blob/main/VERIFICATION.md)） | ✅ |
@@ -216,3 +220,4 @@
 | dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 | 待测 |
 | dsh-defend | [PerryLink/dsh-defend](https://github.com/PerryLink/dsh-defend) | 注入/越狱/密钥泄露检测 + 危险删除门禁：Aho-Corasick 引擎在用户消息、工具参数、工具结果三处按 allow/ask/block 拦截（脱敏 defend/detection 审计事件、defend_report 工具、/defend 命令），并拒绝工作区外的递归删除命令 | 待测 |
 | dsh-simple-wiki-memory | [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) | 简易 Wiki 持久记忆（DSWM）：一个索引文档自动注入 + 每主题一个 md 文件按需读取，省 token 轻量无压力；pending 准入→确认晋升→archive 归档三区 + memory-log 审计 + git 自动备份；纯 Markdown 所见即所得，跨 harness 共享 | 待测 |
+


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugins（家族索引）+ 3 个单插件 |
| 仓库 | https://github.com/MkaliezZ/dsh-plugins |
| 分类 | 🧰 插件集 / 🔌 单插件 |
| 一句话说明 | 16 个 DSH 插件的家族索引：fail-closed 授权安全线、策略测试与诊断、工作区生产力、运行时基础设施 |

## 自检清单

- [x] package.json name 使用 @mkaliezz/* scope（未占用 @deepseek-ai/* 保留命名空间；家族按 npm scope 归组，与 @dsh-external/* 约定并存）
- [x] 仓库已打 dsh-plugin topic（全族 17 仓库）
- [x] 已通过 API 创建 PR 并设置 maintainer_can_modify=true
- [x] 运行时依赖已在各插件 package.json 声明
- [x] 实测：dsh-agentfuse-plugin 已通过本雷达 K8s 运行级验证（PLUGINS-ALL.md 中 [可用] 判定，⭐3）；其余为登记待测

## 改动内容

PLUGINS.md 追加 4 行：🔌 单插件 3 行（dsh-agentfuse-plugin / dsh-evidence-task-board / dsh-test-normalizer）+ 🧰 插件集 1 行（dsh-plugins 家族索引）。

## 备注

- 本次 PR 前已将两个撞名仓库改名以消除同名歧义：dsh-task-board → dsh-evidence-task-board、dsh-test-runner → dsh-test-normalizer（npm 包名保持不变，分别为 @mkaliezz/dsh-task-board 与 @mkaliezz/dsh-test-runner）；旧 URL 由 GitHub 自动重定向。
- dsh-agentfuse-plugin 与 dsh-policy-test 构成策略决策闭环，欢迎重点跟踪 fail-closed 授权线的运行级复测。