### PR TITLE
docs: 登记 dsh-univer-office

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -113,6 +113,7 @@
 | dsh-thinkmeter | [dmz2922990/dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter) | Think 思考行 Token 计量表：把聊天视图流式 Think 预览替换为实时 token 数显示（Thinking ≈ N tokens），落定时精确取 usage.reasoningTokens、缺失时启发式估算，点击可展开/收起完整思考文本（web client 插件，dsh.bundle 一键安装） | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 | dsh-trading-toolkit | [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) | A股+美股行情工具箱：实时行情/OHLCV K线/ADX 三状态信号/回测预览，东方财富免 Key 直连，只读永不下单 | ? |
+| dsh-univer-office | [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | Univer 办公插件：在 DSH 中创建/编辑/检查/交付表格、文档、演示文稿、多维表格和画布，支持 xlsx/docx/pptx 导入导出、实时预览与 worktree 审阅；npm `dsh-univer-office` 0.2.5 | 待测 |
 | dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
## Plugin Information

| Field | Value |
|---|---|
| Plugin name | dsh-univer-office |
| Repository | https://github.com/dream-num/dsh-univer-office |
| Category | 🔌 Single plugin (taxonomy v2 equivalent: 🗂 File & Data) |
| One-line description | Univer office plugin for DeepSeek Harness: create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases, with xlsx/docx/pptx import/export, live preview, and worktree review. |

## Self-Checklist

- [x] `package.json` uses the project-owned namespace `dsh-univer-office`; no `@deepseek-ai/*` reserved namespace
- [x] Repository has the `dsh-plugin` GitHub topic enabled
- [x] **Allow edits from maintainers** is enabled on this PR
- [x] All runtime dependencies are declared (`dependencies` / `peerDependencies`)
- [x] Plugin repository CI passed (Release v0.2.5 build + test), npm package published
- [ ] Pending this radar's runtime-level verification (marked as `待测` in `PLUGINS.md`)

## Changes

| Plugin | Repository | Description |
|---|---|---|
| dsh-univer-office | [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) | Univer office plugin for DeepSeek Harness: create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases, with xlsx/docx/pptx import/export, live preview, and worktree review. |

## Notes

- npm package: `dsh-univer-office` 0.2.5
- License: Apache-2.0
- Category per `docs/CATALOGING.md`: functionally belongs to 🗂 File & Data; filed under 🔌 Single plugin in `PLUGINS.md`
