### PR TITLE
docs: 登记 dsh-research-report

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -110,6 +110,7 @@
 | dsh-thinkmeter | [dmz2922990/dsh-thinkmeter](https://github.com/dmz2922990/dsh-thinkmeter) | Think 思考行 Token 计量表：把聊天视图流式 Think 预览替换为实时 token 数显示（Thinking ≈ N tokens），落定时精确取 usage.reasoningTokens、缺失时启发式估算，点击可展开/收起完整思考文本（web client 插件，dsh.bundle 一键安装） | 待测 |
 | dsh-mmx-bridge | [welsione/dsh-mmx-bridge](https://github.com/welsione/dsh-mmx-bridge) | MiniMax 多模态桥接插件：一个 mmx_bridge 工具覆盖图像理解（VLM）/文生图/文图生视频/语音合成/音乐生成/音频翻唱/联网搜索/用量查询，生成产物经 /mmx-files/ 同源内嵌图片预览与音视频播放器，附 Web 设置页管理卡片；零 npm 运行时依赖 | 待测 |
 | dsh-trading-toolkit | [kentleenot/dsh-trading-toolkit](https://github.com/kentleenot/dsh-trading-toolkit) | A股+美股行情工具箱：实时行情/OHLCV K线/ADX 三状态信号/回测预览，东方财富免 Key 直连，只读永不下单 | ? |
+| dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-research-report |
| 仓库 | https://github.com/PerryLink/dsh-research-report |
| **分类** | 🔬 研究（研究/证据核查类；预归类器命中规则 12 关键词 esearch，人工确认为「研究」） |
| 一句话说明 | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告 |

## 自检清单（提交前逐项确认）

- [x] package.json name 使用自有命名空间（当前为无 scope 的 dsh-research-report；未占用 @deepseek-ai/* 保留命名空间；获得 dsh-external 维护权限后再迁移到 @dsh-external/*）
- [x] 仓库已打 dsh-plugin topic（另含 deepseek-harness、evidence-ledger、verifiable-report、audit、citation-verification）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（官方 @deepseek-ai/* 均为 peerDependencies，含 rc.6 预发布分支）
- [x] 已按自检三步实测通过：

`ash
# 1. 安装最新 dsh 并加载你的插件（等价临时 patch 文件写法；Windows 无进程替换）
 = Join-Path C:\Users\zzhdz\AppData\Local\Temp 'dsh-rr-patch.yml'
'[{op:add,path:/plugins/-,value:{id:dsh-research-report,name:dsh-research-report}}]' | Out-Null
# 实际使用：dsh --profile smoke --patch <patch文件> 任务（真实 DeepSeek API 实测）
`

- [x] 自检结果：真实 DeepSeek API 冒烟通过——evidence_add 实际写入 ev-61f8f4533cb7、ledger_query 实际返回 1 条证据；69/69 测试、typecheck/typecheck:ci/build/verify 全绿；npm 0.1.0 已发布（含 provenance）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告 |

## 备注

- PLUGINS.md 状态列如实填「待测」：未跑本仓库的 k8s 运行级实测流程；已提供真实 npm 发布 + 本地+真实 API 冒烟证据。
- 分类参考：PLUGINS.md 头部列出的 🔬 研究 类（catalog v0.1）；若维护者认为归属其他类更合适，可自由调整。