### PR TITLE
docs: 登记 dsh-plugin-store

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -77,6 +77,7 @@
 | dsh-visual-plugin | [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) | DSH 视觉桥接插件：主模型无视觉时把用户图片转发到任意 OpenAI 兼容视觉模型（DeepSeek (Vision) 包装适配器 + Web 右侧面板配置/测试/历史），自动拦截描述并支持按问题定向提示词 | ✅ |
 | dsh-vision-proxy | [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | DeepSeek 大脑 + 自动识图：GUI 附加的每张图片自动经 OpenAI 兼容 VLM 转译成文字后交给纯文本 DeepSeek——有 key 自动走快速通道（默认 qwen3.7-flash，支持百炼/智谱/OpenRouter 等任意兼容端点），无 key 自动探测本地 Ollama（零配置） | ✅ |
 | DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |
+| dsh-plugin-store | [sandbaseai/dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) | DSH 设置页原生插件市场：实时目录搜索、Tag 筛选、本地安装与已安装包管理；安装前校验运行时验证状态和 npm 包来源 | 待测 |
 | dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审 + 交付报告与逐维度核对（verify 工作流）；/doublecheck 会话命令、en/zh 双语、npm 已发布 0.6.0 | 待测 |
 | dsh-git-plugin | [IT-coder-Yy/dsh-git-plugin](https://github.com/IT-coder-Yy/dsh-git-plugin) | 面向 DSH Web 的可视化 Git 工作台：查看仓库状态、Diff、分支、提交历史与贮藏，点击执行常用 Git 操作，并安全运行 AI 生成的分步骤 Git 提议；npm `dsh-easygit-plugin` 0.2.1，DSH 0.1.0-rc.6 实测 | 待测 |
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | `dsh-plugin-store` |
| 仓库 | https://github.com/sandbaseai/dsh-plugin-store |
| **分类** | 🛒 市场与管理 |
| 一句话说明 | DSH 设置页原生插件市场：实时目录搜索、Tag 筛选、本地安装与已安装包管理；安装前校验运行时验证状态和 npm 包来源。 |

## 自检清单

- [x] package 使用项目自有的公开 `@sandbaseai/*` scope，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已设置 `dsh-plugin` topic
- [x] 所有运行时依赖已声明为 peer dependencies
- [x] 上游分类器命中 `store`，建议分类为 `🛒 市场与管理`
- [x] `python3 scripts/export-plugins-md.py --dry-run` 成功识别登记表
- [x] `git diff --check` 通过

## 运行验证

Preview 5 已在隔离的公开 `@deepseek-ai/dsh@0.1.0-rc.8` profile 中完成安装、配置合成、Web 启动和 Host 路由验证。Store 内部安装路径也分别验证了 runtime-verified npm 包成功激活，以及 action-required 条目被拒绝。

Release: https://github.com/sandbaseai/dsh-plugin-store/releases/tag/v0.1.0-preview.5

## 改动内容

仅在 `PLUGINS.md` 追加一条记录，运行级状态保守标记为“待测”，由本仓库雷达独立复核。