### PR TITLE
docs: 登记 dsh-condense

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -28,6 +28,7 @@
 | dsh-bash-terminal | [MAXeaglet/dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) | Windows 三终端 shell 工具（PowerShell/Git Bash/WSL，默认终端由用户在设置中选择）+ 交互式 PTY 终端 + 官方沙箱对接；4 套件测试 + GitHub Actions CI 全绿 | ✅ |
 | dsh-win32 | [sjh9714/dsh-win32](https://github.com/sjh9714/dsh-win32) | 在 Windows 上把 DSH 用起来：一行装好极简模式的持久 shell（Git Bash/ConPTY，沙箱内可用），npm 可装 | ✅ |
 | dsh-artifact | [dsh-external/dsh-artifact](https://github.com/dsh-external/dsh-artifact) | 制品管理 | ✅ |
+| dsh-condense | [JxaMe/dsh-condense](https://github.com/JxaMe/dsh-condense) | token 优化插件：屏蔽低信号读取、压缩大输出、哈希去重、smart_read 骨架化（tree-sitter）、BM25 检索、真实用量统计+持久化；npm `@jxame/dsh-condense` | ✅ |
 | dsh-split-panes | [dsh-external/dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) | 分屏面板 | ✅ |
 | dsh-sentinel | [fuhefei/dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) | 事件驱动唤醒 agent loop（文件/命令/http/进程/webhook 传感器） | ✅ |
 | dsh-plugin-automations | [Sev7een/dsh-plugin-automations](https://github.com/Sev7een/dsh-plugin-automations) | Web 设置页定时任务：支持准点或 DeepSeek 谷时段执行、单次/每日重复，并持久化任务状态 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-condense |
| 仓库 | [JxaMe/dsh-condense](https://github.com/JxaMe/dsh-condense) |
| 分类 | 🔌 单插件（编码 / Agent 能力） |
| 一句话说明 | token 优化插件：屏蔽低信号读取、压缩大输出、哈希去重、smart_read 骨架化（tree-sitter）、BM25 检索，真实用量统计 + 持久化 |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [x] 运行时依赖已声明（`@deepseek-ai/schemastery` + web-tree-sitter + tree-sitter 语法包）
- [x] headless 加载实测通过：`dsh --profile headless --patch ... "hi"` → 宿主插件 + 主插件均正常加载，无报错

## 备注（想先咨询一下）

> 关于 scope 的一点说明：本插件 npm 包名为 **`@jxame/dsh-condense`**（个人账号 scope），未使用约定中的 `@dsh-external/*` scope。选择个人 scope 的原因：
> 1. 项目从开发期就使用 `@jxame` scope，npm 包已发布（`@jxame/dsh-condense@0.1.0`），改名成本较高；
> 2. 观察到清单中已有多个插件同样使用个人 scope（如 `@mkaliezz/*`、`@linxin666/*` 等），非 `@dsh-external` 应该也是被接受的。
>
> 如果维护者认为必须统一 `@dsh-external/*` scope，我们可以重新评估；否则希望按现状收录，谢谢！

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-condense | [JxaMe/dsh-condense](https://github.com/JxaMe/dsh-condense) | PLUGINS.md 登记一行 |
