### PR TITLE
docs: 登记 dsh-fund-research

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -163,6 +163,11 @@
 | dsh-suite | [whyihaveyou/dsh-suite](https://github.com/whyihaveyou/dsh-suite) | DSH 插件活目录 + 脚手架 + 内置插件商店：785+ 插件每小时刷新、每日兼容 CI 实测、中英双语可搜索目录站；含 create-dsh-plugin 脚手架与 plugin-manager / plugin-notify / plugin-session-export / plugin-team-board 五个 npm 包 | 已测 |
 | dsh-change-budget | [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) | 为每个 DSH Agent 回合设置文件数、修改调用数与 UTF-8 载荷额度；在受支持的文件修改工具执行前阻止超额修改，并对并行调用同步预留额度 | 待测 |
 
+## 📚 学习研究
+
+| 插件 | 仓库 | 说明 | 运行级 |
+|---|---|---|---|
+| dsh-fund-research | [PerryLink/dsh-fund-research](https://github.com/PerryLink/dsh-fund-research) | 中国公募基金确定性研究：天天基金/东方财富公开数据采集（pingzhongdata JS 块、F10 持仓与经理页、个股估值 + push2delay 兜底主机），业绩拆解/持仓穿透/风格归因/经理画像纯函数计算，版本化 Markdown 报告附每个关键数字可回溯到 sha256 源快照的附录；npm dsh-fund-research 已发布；仅供研究，不构成投资建议 | 待测 |
 ## ❓ 未分类
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-fund-research |
| 仓库 | https://github.com/PerryLink/dsh-fund-research |
| **分类** | 📚 学习研究（研究类；classify.py 实跑输出见备注） |
| 一句话说明 | 中国公募基金确定性研究：公开数据采集 + 纯函数指标计算，版本化 Markdown 报告附逐数字可回溯源快照的附录；仅供研究，不构成投资建议 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-fund-research`（未占用 `@deepseek-ai/*` 保留命名空间）；备注：当前未获 `@dsh-external/*` 维护权限，获得后迁移命名空间
- [x] 仓库已打 `dsh-plugin` topic（9 个 topics：dsh / dsh-plugin / deepseek-harness / cordis / fund-research / mutual-fund / investment-research / finance / research-report）
- [x] 已在 PR 页面勾选 Allow edits from maintainers（保持默认允许维护者编辑）
- [x] 所有运行时依赖已声明（peerDependencies 对齐 0.1.0-rc.6 钉版；零 runtime dependencies）
- [x] 已按自检三步实测通过（Windows 无 /dev/fd 进程替换，用等价临时 profile 实测）：

```bash
# 等价实测：真实 tarball 装入隔离临时 profile（DSH_HOME=.tmp/dsh-home, profile td）
dsh plugin --profile td add '@deepseek-ai/dsh-base@0.1.0-rc.6' '@deepseek-ai/dsh-headless@0.1.0-rc.6' dsh-fund-research-0.1.1.tgz
dsh --profile td --dump-config   # 输出含 dsh-fund-research 行与配置默认值
dsh --profile td "Reply with exactly: ok"   # keyless 冒烟 2s 得 MISSING_CREDENTIAL = 插件树加载成功
dsh plugin --profile td remove dsh-fund-research  # 卸载后行移除、profile 完好
```

- [x] 自检结果贴这里：加载成功（--dump-config 挂载断言 + keyless 冒烟 2s MISSING_CREDENTIAL，卸载可逆）；113 个单测全绿（真实 Context/Session/ToolRuntime），真实网络 E2E 封存 161725 报告零缺口

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-fund-research | [PerryLink/dsh-fund-research](https://github.com/PerryLink/dsh-fund-research) | 中国公募基金确定性研究：公开数据采集 + 纯函数指标计算，版本化报告附逐数字可回溯源快照的附录 |

## 备注

- 预归类器实跑：`python scripts/classify.py "dsh-fund-research" "中国公募基金确定性研究报告：公开数据采集与纯函数指标计算，版本化报告附每数字可回溯源快照附录"` → 建议分类 `🗂 文件数据`（命中规则：数据）。因规则序先于「📚 学习研究」，且插件实际定位是研究报告（repository keywords: fund-research / investment-research / research-report），按 taxonomy 边界取「📚 学习研究」；如维护者认为「🗂 文件数据」更贴切可直接改分类。
- 运行级如实填「待测」：未在 k8s 实测流程上验证。