### PR TITLE
docs: 登记 dsh-plugin-store

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -77,6 +77,7 @@
 | dsh-visual-plugin | [jyh20030112/dsh-visual-plugin](https://github.com/jyh20030112/dsh-visual-plugin) | DSH 视觉桥接插件：主模型无视觉时把用户图片转发到任意 OpenAI 兼容视觉模型（DeepSeek (Vision) 包装适配器 + Web 右侧面板配置/测试/历史），自动拦截描述并支持按问题定向提示词 | ✅ |
 | dsh-vision-proxy | [Flyvhidbwo/dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | DeepSeek 大脑 + 自动识图：GUI 附加的每张图片自动经 OpenAI 兼容 VLM 转译成文字后交给纯文本 DeepSeek——有 key 自动走快速通道（默认 qwen3.7-flash，支持百炼/智谱/OpenRouter 等任意兼容端点），无 key 自动探测本地 Ollama（零配置） | ✅ |
 | DSH-Plugins-Marketplace | [bradeGithub/DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) | DSH 插件市场：聚合 GitHub `dsh-plugin` 话题插件，Web GUI 一键安装/更新/已安装识别（含预装插件自动比对），静态索引 CI 每 2 小时刷新，中英双语 | ✅ |
+| dsh-plugin-store | [sandbaseai/dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) | DSH Settings 原生社区插件商店：浏览、搜索、Tag 筛选与已安装包管理；一键安装仅接受 Leaderboard 已验证且运行验证通过的 npm 包规范，非 npm 来源保持手动安装边界 | 待测 |
 | dsh-doublecheck | [PerryLink/dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) | 工程纪律插件：交付前三查——需求审讯（grill-requirements 技能）+ 红绿测试证据门 + 对抗评审 + 交付报告与逐维度核对（verify 工作流）；/doublecheck 会话命令、en/zh 双语、npm 已发布 0.6.0 | 待测 |
 | dsh-git-plugin | [IT-coder-Yy/dsh-git-plugin](https://github.com/IT-coder-Yy/dsh-git-plugin) | 面向 DSH Web 的可视化 Git 工作台：查看仓库状态、Diff、分支、提交历史与贮藏，点击执行常用 Git 操作，并安全运行 AI 生成的分步骤 Git 提议；npm `dsh-easygit-plugin` 0.2.1，DSH 0.1.0-rc.6 实测 | 待测 |
 
@@ -229,4 +230,3 @@
 | dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 | 待测 |
 | dsh-defend | [PerryLink/dsh-defend](https://github.com/PerryLink/dsh-defend) | 注入/越狱/密钥泄露检测 + 危险删除门禁：Aho-Corasick 引擎在用户消息、工具参数、工具结果三处按 allow/ask/block 拦截（脱敏 defend/detection 审计事件、defend_report 工具、/defend 命令），并拒绝工作区外的递归删除命令 | 待测 |
 | dsh-simple-wiki-memory | [rainow/dsh-simple-wiki-memory](https://github.com/rainow/dsh-simple-wiki-memory) | 简易 Wiki 持久记忆（DSWM）：一个索引文档自动注入 + 每主题一个 md 文件按需读取，省 token 轻量无压力；pending 准入→确认晋升→archive 归档三区 + memory-log 审计 + git 自动备份；纯 Markdown 所见即所得，跨 harness 共享 | 待测 |
-


### PR DESCRIPTION
Supersedes #265, which we withdrew ourselves before maintainer review. The canonical awesome-directory listing has since merged; this repository serves a distinct radar/test audience, so this submission follows its own registration workflow.

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | `dsh-plugin-store` |
| 仓库 | https://github.com/sandbaseai/dsh-plugin-store |
| **分类** | 🛒 市场与管理 |
| 一句话说明 | DSH Settings 原生社区插件商店：浏览、搜索、Tag 筛选与已安装包管理；一键安装仅接受 Leaderboard 已验证且运行验证通过的 npm 包规范。 |

## 自检清单

- [x] package 使用 SandbaseAI 自有公开 scope `@sandbaseai/dsh-plugin-store`，未占用 `@deepseek-ai/*` 保留命名空间（不是 `@dsh-external/*`，请维护者按组织自有 scope 政策判断）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 允许维护者编辑该 PR
- [x] 所有运行时依赖均声明为 `peerDependencies`
- [x] 仓库分类器命中 `store`，返回 `🛒 市场与管理`
- [x] `python3 scripts/export-plugins-md.py --dry-run` 成功，识别 192 个登记仓库
- [x] `git diff --check` 通过

## 运行验证

Preview 5 已在隔离的公开 `@deepseek-ai/dsh@0.1.0-rc.8` Web profile 完成：

- Store tarball 安装与 bundle 激活
- 配置合成、Web 启动、客户端模块与 catalog route
- runtime-verified npm 包安装成功
- `action_required` 条目被拒绝
- 安装输入仅接受单个 npm 包规范；URL、git spec、空白和 shell 语法均拒绝

Release: https://github.com/sandbaseai/dsh-plugin-store/releases/tag/v0.1.0-preview.5
SHA-256: https://github.com/sandbaseai/dsh-plugin-store/releases/download/v0.1.0-preview.5/SHA256SUMS

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-plugin-store | https://github.com/sandbaseai/dsh-plugin-store | DSH 原生设置页插件商店；保守标记为“待测”，由本仓库雷达独立复核 |