### PR TITLE
Add dsh-plugin-hub

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -119,6 +119,7 @@
 | dsh-experts | [fuchao2pku/dsh-experts](https://github.com/fuchao2pku/dsh-experts) | DSH 设置页内置「专家市场」：浏览/搜索社区专家与专家团、查看详情并复制到输入框；默认消费 awesome-dsh-experts 目录（7 个种子专家/团），rc.6 web profile 实测 0 加载错误、27 测试全绿 | ✅ |
 | dsh-desk-pet | [anneheartrecord/dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) | macOS 桌宠：真的 AppKit 置顶窗口而不是页面里的挂件，全屏 Space 也盖得住；六种状态跟着本地 DSH 走（空闲／干活／等你确认／报错／刚跑完／打盹），原生右键菜单含免打扰与会话清单；自带的 skill 用你自己的画图工具和额度把一张照片扩成整套十八个姿势的皮肤，装在包外，升级不会删。跑系统自带的 Python 与 ctypes，零运行时依赖，不用 Electron。**仅 macOS** | 待测 |
 | dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
+| dsh-plugin-hub | [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) | DSH 插件管理面板：一键启停 + 多源市场（GitHub/Gitee/自定义）+ 静态索引市场（500+ 插件/300 技能）+ 技能安装/停用 + 套装一键装配 + 框架升级适配 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 收录申请：dsh-plugin-hub

[Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH 插件管理面板与市场：

- 一键启用/停用已安装插件（HMR 生效），基础设施保护
- 多源插件市场：GitHub / Gitee 直装 / 自定义搜索源、多源汇总、★ 官方筛选
- 静态索引市场：jsDelivr CDN 分发 500+ 插件 / 300 技能，零 GitHub API 调用
- 技能市场：搜索（agent-skills/claude-skills/dsh-skill）、一键安装/停用/删除、系统保护
- 套装（submodule 聚合仓库）一键装配：bundle 插件 / 技能 / agent 预设 / 普通插件
- 自动收录 CI（每 6 小时刷新索引）、框架升级适配（配置备份 + 补丁重打）
- 已打 dsh-plugin topic

感谢收录！

---

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-hub |
| 仓库 | https://github.com/Noob-stupid/dsh-plugin-hub |
| **分类** | 🛒 市场与管理 |
| 一句话说明 | DSH 插件管理面板：一键启停 + 多源市场（GitHub/Gitee/自定义）+ 静态索引市场（500+ 插件/300 技能）+ 技能安装/停用 + 套装一键装配 + 框架升级适配 |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [ ] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）——当前为 `@deepseek-ai/dsh-plugin-console`，如不符请在评审中指出
- [ ] 已在 fork Settings → General 开启 **Allow edits and access to secrets by maintainers**
- [ ] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [ ] 已按自检三步实测通过

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-plugin-hub | [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) | DSH 插件管理面板：一键启停 + 多源市场（GitHub/Gitee/自定义）+ 静态索引市场（500+ 插件/300 技能）+ 技能安装/停用 + 套装一键装配 + 框架升级适配 | 待测 |

## 备注

- 已在 PLUGINS.md「🔌 单插件」分类末尾追加一行，未发现重复条目
