### PR TITLE
Add dsh-socrates plugin to PLUGINS.md

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -120,6 +120,7 @@
 | dsh-experts | [fuchao2pku/dsh-experts](https://github.com/fuchao2pku/dsh-experts) | DSH 设置页内置「专家市场」：浏览/搜索社区专家与专家团、查看详情并复制到输入框；默认消费 awesome-dsh-experts 目录（7 个种子专家/团），rc.6 web profile 实测 0 加载错误、27 测试全绿 | ✅ |
 | dsh-desk-pet | [anneheartrecord/dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) | macOS 桌宠：真的 AppKit 置顶窗口而不是页面里的挂件，全屏 Space 也盖得住；六种状态跟着本地 DSH 走（空闲／干活／等你确认／报错／刚跑完／打盹），原生右键菜单含免打扰与会话清单；自带的 skill 用你自己的画图工具和额度把一张照片扩成整套十八个姿势的皮肤，装在包外，升级不会删。跑系统自带的 Python 与 ctypes，零运行时依赖，不用 Electron。**仅 macOS** | 待测 |
 | dsh-research-report | [PerryLink/dsh-research-report](https://github.com/PerryLink/dsh-research-report) | 证据账本与可验证报告引擎：内容寻址的声明-快照绑定与逐字节核查，产出带逐条判定与 SHA-256 清单封存的版本化报告；npm 0.1.0 已发布 | 待测 |
+| dsh-socrates | [Cruciforms/dsh-socrates](https://github.com/Cruciforms/dsh-socrates) | 苏格拉底式澄清优先的深度研究插件：自适应多轮研究、交叉验证（声明级三分裁决+单跳回补）、程序化引用审计、学术三源（arXiv/PubMed/S2）、模型分层降本（Pro/Flash） | 待测 |
 | open-design | [nexu-io/open-design](https://github.com/nexu-io/open-design) | DSH 设计插件：开源 Claude Design 替代（Top50 精选成员，registry 插队实测） | 待测（registry 插队实测） |
 | ouroboros | [Q00/ouroboros](https://github.com/Q00/ouroboros) | Agent OS：agent 自我变强、人只守底线（Top50 Booster 成员，registry 插队实测） | 待测（registry 插队实测） |
 | dsh-anchored-standard | [xiaobright/dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) | 两阶段 DSH 预设：极简模式对齐启动 → 全量装载（Top50 Booster 成员，registry 插队实测） | 待测（registry 插队实测） |


### PR DESCRIPTION

docs: 登记 dsh-socrates

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-socrates |
| 仓库 | https://github.com/Cruciforms/dsh-socrates |
| **分类** | 🔬 研究 |
| 一句话说明 | 苏格拉底式澄清优先的深度研究插件：自适应多轮研究、交叉验证、引用审计、学术三源、模型分层降本 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用无 scope 命名 `dsh-socrates`（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies: @deepseek-ai/dsh-tools ^0.1.0-rc.6`）
- [x] 已按自检三步实测通过：

```bash
# 1. 安装最新 dsh 并加载你的插件
dsh plugin --profile headless --patch <(printf -- '- insert:\n    - id: dsh-socrates\n      name: dsh-socrates\n') "hi"
# 2. 无报错即通过加载级；有报错按提示修依赖声明
# 3. 声明所有运行时依赖（react 等）到 package.json dependencies
```

- [x] 自检结果贴这里：DSH 0.1.0-rc.8 实测加载成功，`deep_research` / `deepresearch_fetch` 工具注册正常，M0-M5.2 全部验收通过（自适应多轮收敛、交叉验证三分裁决、引用审计、学术三源）。

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-socrates | [Cruciforms/dsh-socrates](https://github.com/Cruciforms/dsh-socrates) | 苏格拉底式澄清优先的深度研究插件：自适应多轮研究、交叉验证（声明级三分裁决+单跳回补）、程序化引用审计、学术三源（arXiv/PubMed/S2）、模型分层降本（Pro/Flash） | 待测 |

## 备注

作者已在 DSH 0.1.0-rc.8 实测验收 M0-M5.2，运行级待贵方 K8s 验证。