### PR TITLE
docs: 登记 tabbit-browser

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -129,6 +129,7 @@
 | EverOS | [EverMind-AI/EverOS](https://github.com/EverMind-AI/EverOS) | 全 agent 便携记忆层：本地优先 Markdown-native（Top50 成员，registry 插队实测） | 待测（registry 插队实测） |
 | openpencil | [ZSeven-W/openpencil](https://github.com/ZSeven-W/openpencil) | OpenPencil 设计工具本体（DSH 适配器 dsh-openpencil 已另有条目；本体插队实测） | 待测（registry 插队实测） |
 | EchoBird | [edison7009/EchoBird](https://github.com/edison7009/EchoBird) | 多引擎一键安装与模型切换（Top50 成员，registry 插队实测） | 待测（registry 插队实测） |
+| tabbit-browser | [Tabbit-Browser/dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) | 让 DSH Agent 通过 Tabbit 浏览器自带的 `tabbit-cli`（任务隔离的 Playwright CLI）控制真实网页、复用真实登录态，完成网页自动化、信息提取、QA 与基准测试；bundle 随安装自动注册 `tabbit-browser` skill（持久化任务空间、locator 与等待、截图、回执与恢复）+ `tabbit_browser_install` 环境预检工具（要求正式版 ≥ 1.9.0，缺失或过低时按系统地区后台下载国内 `tabbit.com` / 国际 `tabbit.ai` 对应安装包到 Downloads 并通知绝对路径）；MIT，npm `tabbit-browser` | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |

--- a/catalog/plugins/1334076307.json
+++ b/catalog/plugins/1334076307.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "github:1334076307",
+  "repository": {
+    "full_name": "Tabbit-Browser/dsh-plugin",
+    "url": "https://github.com/Tabbit-Browser/dsh-plugin"
+  },
+  "package": {
+    "name": "tabbit-browser",
+    "entry": "./index.js"
+  },
+  "curation": {
+    "state": "candidate",
+    "category": "🗂 文件数据",
+    "description_zh": "让 DSH Agent 通过 Tabbit 浏览器自带的 tabbit-cli（任务隔离的 Playwright CLI）控制真实网页、复用真实登录态，完成网页自动化、信息提取、QA 与基准测试；bundle 随安装自动注册 tabbit-browser skill + tabbit_browser_install 环境预检/按地区下载安装包工具"
+  },
+  "ownership": {
+    "method": "maintainer_pr",
+    "verified_at": "2026-08-21"
+  },
+  "lifecycle": {
+    "state": "active"
+  },
+  "disclosures": {
+    "risk": "medium",
+    "network": true,
+    "filesystem": "arbitrary",
+    "credentials": [],
+    "data_handling_url": ""
+  }
+}


### PR DESCRIPTION
为 Tabbit-Browser/dsh-plugin 在 PLUGINS.md「🔌 单插件」表格追加一行，并新增 catalog/plugins/1334076307.json 人工事实条目（schema v1 校验通过）。

插件让 DSH Agent 通过 Tabbit 浏览器自带的 tabbit-cli（任务隔离的 Playwright CLI） 控制真实网页、复用真实登录态，完成网页自动化、信息提取、QA 与基准测试；bundle
随安装自动注册 tabbit-browser skill + tabbit_browser_install 环境预检/按地区 下载安装包工具。MIT，npm tabbit-browser，⭐90。

分类（taxonomy v2）：🗂 文件数据（浏览器自动化/网页抽取，与 dsh-browser 同域）。 运行级：待测（依赖宿主机已安装 Tabbit Browser ≥ 1.9.0 及 tabbit-cli 常驻运行时）。

<!--
  插件登记 PR 模板 —— 按此格式提交，合并后立即进入目录。
  目标文件：PLUGINS.md（表格追加一行即可）。
-->

> 📌 **标题格式**：`docs: 登记 <插件名>`（示例：`docs: 登记 dsh-balance`）——请勿使用其他标题格式。
>
> 🛠 **合并小贴士（重要）**：请让维护者能帮你 rebase——两种方式任选其一：
> 1. 提交 PR 后，在 PR 页面右侧勾选 **Allow edits from maintainers**；
> 2. 或在自己 fork 仓库的 Settings → General 勾选 **Allow edits and access to secrets by maintainers**（一次开启，以后所有 PR 自动允许）。
>
> 🙏 **致歉说明**：最近 README/PLUGINS.md 正在高速更改中（每日快照更新 + 分类体系重构），多个 PR 同时登记同一区域时可能产生冲突，处理可能稍显延迟，请见谅。

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | <!-- 与 repo 名一致，如 my-plugin --> |
| 仓库 | <!-- 如 https://github.com/dsh-external/my-plugin --> |
| **分类** | <!-- 必填：13 类之一（ taxonomy v2，见 docs/CATALOGING.md ），格式如「🧠 记忆增强」。提 PR 前可用预归类器：`python3 scripts/classify.py "<插件名>" "<描述>"` --> |
| 一句话说明 | <!-- 功能描述（也是分类判定输入，请具体） --> |

## 自检清单（提交前逐项确认）

- [ ] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
- [ ] 仓库已打 `dsh-plugin` topic
- [ ] 已在 PR 页面勾选 **Allow edits from maintainers**（或已在 fork Settings → General 开启同项，一次开启后续自动生效）
- [ ] 所有运行时依赖已声明（`dependencies` / `peerDependencies`）
- [ ] 已按自检三步实测通过：

```bash
# 1. 安装最新 dsh 并加载你的插件
dsh --profile headless --patch <(printf -- '- insert:\n    - id: my-plugin\n      name: @dsh-external/my-plugin\n') "hi"
# 2. 无报错即通过加载级；有报错按提示修依赖声明
# 3. 声明所有运行时依赖（react 等）到 package.json dependencies
```

- [ ] 自检结果贴这里：<!-- 如「加载成功，工具 X 调用正常」或贴报错说明 -->

## 改动内容

<!-- PLUGINS.md 追加的行（直接贴出）：-->

| 插件 | 仓库 | 说明 |
|---|---|---|
| <!-- 插件名 --> | <!-- 仓库链接 --> | <!-- 说明 --> |

## 备注

<!-- 可选：已知问题、待适配项、想被雷达重点跟踪的维度等 -->
