### PR TITLE
docs: 登记 pi2dsh

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -171,6 +171,7 @@
 | dsh-work | [vibeinging/dsh-work](https://github.com/vibeinging/dsh-work) | 以 dsh 为骨、codex 为皮的桌面 app | 待测 |
 | deepseek-harness-desktop | [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面外壳:1:1 官方 Web UI、内置服务器托管、托盘驻留与掉线自动恢复 | ✅ |
 | dsh-remote-sandbox | [weijiafu14/dsh-remote-sandbox](https://github.com/weijiafu14/dsh-remote-sandbox) | 生产级远程执行世界：E2B 沙箱内纯 JS sidecar，fs/subprocess 单次往返、进程输出有界、心跳保活、崩溃透明恢复（resume/recreate）、tar 工作区同步；修复官方 e2b POC 两处 host 假设。43 项测试（含 6 项真机 E2E）全绿 | 已测 |
+| pi2dsh | [weijiafu14/pi2dsh](https://github.com/weijiafu14/pi2dsh) | Pi 生态兼容层：用一个 DSH Host ABI 让未修改的 Pi 扩展包作为原生 DSH 插件运行，桥接工具、命令与 hooks、会话与子代理、模型 Provider 与 OAuth、MCP 及 Web UI；npm `pi2dsh`，持续以契约测试和真实 DSH E2E 验证 | ✅ |
 | dsh-session-cleaner-cli | [ChenChen913/dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) | DSH 会话数据离线清理 CLI：按工作区交互/命令删除会话（回收站+恢复+自动备份）、同步工作区账目与投影缓存、修剪幽灵条目；零依赖 Node≥18，8 项端到端测试全绿 + CI | 待测 |
 | dsh-suite | [whyihaveyou/dsh-suite](https://github.com/whyihaveyou/dsh-suite) | DSH 插件活目录 + 脚手架 + 内置插件商店：785+ 插件每小时刷新、每日兼容 CI 实测、中英双语可搜索目录站；含 create-dsh-plugin 脚手架与 plugin-manager / plugin-notify / plugin-session-export / plugin-team-board 五个 npm 包 | 已测 |
 | dsh-change-budget | [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) | 为每个 DSH Agent 回合设置文件数、修改调用数与 UTF-8 载荷额度；在受支持的文件修改工具执行前阻止超额修改，并对并行调用同步预留额度 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | pi2dsh |
| 仓库 | https://github.com/weijiafu14/pi2dsh |
| **分类** | 🛠 基础设施 |
| 一句话说明 | Pi 生态兼容层：用一个 DSH Host ABI 让未修改的 Pi 扩展包作为原生 DSH 插件运行，桥接工具、命令与 hooks、会话与子代理、模型 Provider 与 OAuth、MCP 及 Web UI |

## 自检清单

- [x] npm 包名 `pi2dsh` 由仓库作者控制，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已添加 `dsh-plugin` topic
- [x] 所有运行时依赖已声明
- [x] `dsh plugin --profile web add pi2dsh` 可从 npm 安装并加载
- [x] 本仓库当前 `PLUGINS-ALL.md` 已将 pi2dsh 标记为 `[可用]`，`reports/agent-test/2026-08-14.md` 同样记录为 `✅ 可用`
- [x] pi2dsh 仓库持续运行契约测试、干净 npm 安装回归和真实 DSH Web/headless E2E

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| pi2dsh | [weijiafu14/pi2dsh](https://github.com/weijiafu14/pi2dsh) | Pi 生态兼容层：用一个 DSH Host ABI 让未修改的 Pi 扩展包作为原生 DSH 插件运行，桥接工具、命令与 hooks、会话与子代理、模型 Provider 与 OAuth、MCP 及 Web UI；npm `pi2dsh`，持续以契约测试和真实 DSH E2E 验证 | ✅ |

## 备注

这是把已经进入自动全量索引、且已有运行级可用结论的 pi2dsh 登记进社区维护的 `PLUGINS.md`；本 PR 不修改自动生成数据，也不申请进入精选 Top 50。