### PR TITLE
docs: 登记 dsh-peekfile-everything

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -266,6 +266,7 @@
 | dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 | 待测 |
 | dsh-defend | [PerryLink/dsh-defend](https://github.com/PerryLink/dsh-defend) | 注入/越狱/密钥泄露检测 + 危险删除门禁：Aho-Corasick 引擎在用户消息、工具参数、工具结果三处按 allow/ask/block 拦截（脱敏 defend/detection 审计事件、defend_report 工具、/defend 命令），并拒绝工作区外的递归删除命令 | 待测 |
 | dsh-sessions-manager | [TOBYCAI/dsh-sessions-manager](https://github.com/TOBYCAI/dsh-sessions-manager) | 统一「会话管理」面板：归档/恢复/彻底删除/跨工作区移动/批量多选/工作区标签 + 每条会话详情（磁盘占用、轮次/步骤/消息、工具使用、write/edit 文件、血统）；卡片操作收敛为 ⋯ 菜单 | 待测 |
+| dsh-peekfile-everything | [fastengiel-kurai/dsh-peekfile-everything](https://github.com/fastengiel-kurai/dsh-peekfile-everything) | DSH 全盘文件搜索与预览插件：统一搜索工作目录、WSL 和 Windows Everything 索引，支持本地多格式预览、路径接管、会话引用，并可与 Better Sidebar 配合管理工作目录内文件 | 待测 |
 | Blue | [dsh-blue/blue](https://github.com/dsh-blue/blue) | 插件树式终端界面（TUI）：流式 markdown 会话流、工具卡片、模糊命令补全、主题热切换与 /btw 旁路提问，每个界面组件都是可热替换的 Cordis 插件；npm `@dsh-blue/blue`（`rc` 线，`dsh plugin --profile blue add @dsh-blue/blue@rc` 安装），双语文档站 dsh-blue.dev | 待测 |
 
 | dsh-nuke-plugin | [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) | 事务化强力卸载引擎：validate/preview/execute/undo 四段式 + Saga 回滚、WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演（成功率/期望回收/最脆弱步骤）；21 工具 222 测试 MIT | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-peekfile-everything |
| 仓库 | https://github.com/fastengiel-kurai/dsh-peekfile-everything |
| **分类** | 🗂 文件数据 |
| 一句话说明 | DSH 全盘文件搜索与预览插件：统一搜索工作目录、WSL 和 Windows Everything 索引，支持本地多格式预览、路径接管、会话引用，并可与 Better Sidebar 配合管理工作目录内文件。 |

## 自检清单

- [x] 包名使用作者有权控制的 `@kurai/*` 命名空间，未占用 `@deepseek-ai/*` 或无权限的 `@dsh-external/*`；符合仓库当前“使用有权控制的命名空间”规则
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已允许维护者编辑 PR 分支
- [x] 所有运行时依赖已声明在 `dependencies` / `peerDependencies`
- [x] 已完成安装、构建、加载与最小功能自检

自检环境与结果：

- DSH `0.1.0-rc.8`
- DSH mainline commit `141eb6fef83422698aef7a981029e843e8161534`
- Windows 11 + WSL2 Ubuntu 24.04
- Node.js >= 22
- Better Sidebar 0.14.0（可选集成）
- `node --test tests/*.test.js`：17/17 通过
- `node build.mjs`：通过
- `node --check src/client.js`：通过
- `node --check src/host.js`：通过
- `npm pack --dry-run`：Host/Client 入口、bundle patch、README 与 LICENSE 均在安装包中
- DSH Web 实机冒烟：PeekFiles 入口、搜索、文件预览与设置页可加载

验证记录：https://github.com/fastengiel-kurai/dsh-peekfile-everything/blob/main/VERIFICATION.md

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-peekfile-everything | [fastengiel-kurai/dsh-peekfile-everything](https://github.com/fastengiel-kurai/dsh-peekfile-everything) | DSH 全盘文件搜索与预览插件：统一搜索工作目录、WSL 和 Windows Everything 索引，支持本地多格式预览、路径接管、会话引用，并可与 Better Sidebar 配合管理工作目录内文件 | 待测 |

## 备注

PeekFile 主要负责跨工作目录、WSL 与 Windows 全盘搜索及预览；Better Sidebar 可选负责当前工作目录内文件管理。Everything、文档转换和 OCR 工具均为可选依赖，权限与数据边界已在插件 README 和 SECURITY.md 中说明。