### PR TITLE
docs: 登记 dsh-fast

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -141,6 +141,7 @@
 | TokenLedger | [zh667/TokenLedger](https://github.com/zh667/TokenLedger) | 侧栏用量面板：把 token 归因到实际服务请求的中继站（121★，rc.8 实测 ✅） | ✅ |
 | dsh-easyrewrite | [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) | DSH Web 用户消息气泡内联编辑与撤回插件：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n（中/英/日）；npm `dsh-easyrewrite`（dsh.bundle.patch → cordis.patch.yml，`dsh plugin add` 一键安装） | 待测 |
 | tabbit-browser | [Tabbit-Browser/dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) | 让 DSH Agent 通过 Tabbit 浏览器自带的 `tabbit-cli`（任务隔离的 Playwright CLI）控制真实网页、复用真实登录态，完成网页自动化、信息提取、QA 与基准测试；bundle 随安装自动注册 `tabbit-browser` skill（持久化任务空间、locator 与等待、截图、回执与恢复）+ `tabbit_browser_install` 环境预检工具（要求正式版 ≥ 1.9.0，缺失或过低时按系统地区后台下载国内 `tabbit.com` / 国际 `tabbit.ai` 对应安装包到 Downloads 并通知绝对路径）；MIT，npm `tabbit-browser` | 待测 |
+| dsh-fast | [PerryLink/dsh-fast](https://github.com/PerryLink/dsh-fast) | 只读性能诊断：会话加载/恢复耗时、spill 命中计数、压缩次数与触发、上下文注入体量（AGENTS.md/技能/工具 schema 的 token 占比）与 LLM 缓存命中率，经 /fast 命令与 fast_report 工具呈现，异步采样不阻塞模型路径；npm `dsh-fast` 0.1.3 | 待测 |
 | dsh-data-quality | [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域；npm `dsh-data-quality` 已发布 0.1.3 | 待测 |
 ## 🧰 插件集
 


### PR DESCRIPTION
> 注：本 PR 正文原文因编码问题显示为乱码，已按登记模板重建为可读版（2026-09-07）。

## 插件信息

| 项目 | 值 |
|---|---|
| 插件名称 | dsh-fast |
| 仓库 | https://github.com/PerryLink/dsh-fast |
| **分类** | 🔧 基建部署（taxonomy v2 规则 11「监控」关键词最贴近：性能诊断 / 可观测性） |
| 一句话说明 | 只读性能诊断：会话加载/恢复耗时、spill 命中计数、压缩次数与触发、上下文注入体量（AGENTS.md/技能/工具 schema 的 token 占比）与 LLM 缓存命中率，经 /fast 命令与 fast_report 工具呈现，异步采样不阻塞模型路径 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-fast`（未占用 `@deepseek-ai/*` 保留命名空间；README「最低收录条件」要求使用有权控制的命名空间，`dsh-fast` 为作者自有并已发布 npm，暂未获 `dsh-external` 维护权限，获得后再迁移 `@dsh-external/*`）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（或 fork Settings → General 开启）
- [x] 所有运行时依赖已声明（官方 `@deepseek-ai/*` 走 `peerDependencies`）
- [ ] 已按自检三步实测通过：**未执行**——本沙箱环境无 `dsh` CLI 与 `DEEPSEEK_API_KEY`，无法完成 k8s 运行级实测；如实填「待测」，未伪造加载成功。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-fast | [PerryLink/dsh-fast](https://github.com/PerryLink/dsh-fast) | 只读性能诊断：会话加载/恢复耗时、spill 命中计数、压缩次数与触发、上下文注入体量（AGENTS.md/技能/工具 schema 的 token 占比）与 LLM 缓存命中率，经 /fast 命令与 fast_report 工具呈现，异步采样不阻塞模型路径 |

## 备注

- 运行状态如实填「待测」：未执行标准件 D 的 K1–K3 运行级实测。
- 命名空间：当前使用自有命名空间 `dsh-fast`（npm 已发布 0.1.3），未占用 `@deepseek-ai/*`；获得 `dsh-external` 维护权限后再迁移 `@dsh-external/*`。
- 分类依据：taxonomy v2 规则 11「🔧 基建部署」的「监控」关键词最贴近（性能诊断 / 可观测性）；若维护者认为更贴近其他类，欢迎调整。