### PR TITLE
docs: 登记 dsh-local-ai

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -185,6 +185,7 @@
 | dsh-suite | [whyihaveyou/dsh-suite](https://github.com/whyihaveyou/dsh-suite) | DSH 插件活目录 + 脚手架 + 内置插件商店：785+ 插件每小时刷新、每日兼容 CI 实测、中英双语可搜索目录站；含 create-dsh-plugin 脚手架与 plugin-manager / plugin-notify / plugin-session-export / plugin-team-board 五个 npm 包 | 已测 |
 | dsh-change-budget | [Raphaelutumn/dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) | 为每个 DSH Agent 回合设置文件数、修改调用数与 UTF-8 载荷额度；在受支持的文件修改工具执行前阻止超额修改，并对并行调用同步预留额度 | 待测 |
 | dshscan | [shaoshi20/dshscan](https://github.com/shaoshi20/dshscan) | DSH 插件安全审查器：风险评分/严重等级/证据/安装建议；静态+语义双通道、DSH 特有攻击面规则、npm 源码扫描与 audit、批量扫描、HTML 报告 + Web Dashboard（npm: @shaoshi/dshscan） | 待测 |
+| dsh-local-ai | [PerryLink/dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) | Ollama 本地模型接入：ollama_list/pull/remove/show 与健康检查，以官方 LlmAdapter 注册 Ollama 路由并按 model_route 规则（离线优先/长文本/隐私）分流、失败自动回退云端；/ollama 命令一键总览；npm dsh-local-ai 已发布 | 待测 |
 
 ## 📚 学习研究
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-local-ai |
| 仓库 | https://github.com/PerryLink/dsh-local-ai |
| **分类** | 🛠 基建部署（模型接入；classify.py 无关键词命中→兜底「其他」，按 docs/CATALOGING.md「MCP/模型接入 → 基建部署」边界归入，详见备注） |
| 一句话说明 | Ollama 本地模型接入：模型发现/拉取/删除/查看与健康检查，官方 LlmAdapter 注册 Ollama 路由并按任务/关键词分流、失败自动回退云端；/ollama 命令一键总览 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-local-ai`（未占用 `@deepseek-ai/*` 保留命名空间）；备注：当前未获 `@dsh-external/*` 维护权限，获得后迁移命名空间
- [x] 仓库已打 `dsh-plugin` topic（topics：dsh / dsh-plugin / deepseek-harness / ollama / local-llm / local-models / offline / privacy / model-routing）
- [x] 已在 PR 页面勾选 Allow edits from maintainers（保持默认允许维护者编辑）
- [x] 所有运行时依赖已声明（peerDependencies 对齐 0.1.1-rc.2 官方 peer：@deepseek-ai/cordis、dsh-llm、dsh-tools、dsh-subprocess、dsh-commands、dsh-timeout、dsh-attachment、schemastery；零 runtime dependencies）
- [x] 已按自检三步实测（Windows 无 /dev/fd 进程替换，用等价临时 profile 实测）：
  1. `dsh plugin --profile t-ea add dsh-local-ai` — 真实 npm 安装成功（33 包，Done in 4.8s）
  2. `dsh --profile t-ea --dump-config` — 无报错，输出含 `# == dsh-local-ai` 段与完整默认配置（baseURL/requestTimeoutMs/graceMs/defaultContextWindow/maxTokens/models:[]/route:[]，bundle manifest 解析成功）
  3. 运行时依赖已声明为 peerDependencies，无未声明的 react 等运行时依赖
- [x] 自检结果贴这里：bundle manifest 挂载断言通过；headless 冒烟（`dsh --profile t-ea "hi"`）在本沙箱 60–90s 超时未返回明确结果（headless 非交互在无 key 下挂起），故不声明「运行级可用」

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-local-ai | [PerryLink/dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) | Ollama 本地模型接入：ollama_list/pull/remove/show 与健康检查，以官方 LlmAdapter 注册 Ollama 路由并按 model_route 规则（离线优先/长文本/隐私）分流、失败自动回退云端；/ollama 命令一键总览；npm dsh-local-ai 已发布 |

## 备注

- 预归类器：本环境无 python 运行时，按 `scripts/classify.py` 的 RULES（同名正则，声明序首个命中）手工复算 → ❓ 其他（无关键词命中）；据 `docs/CATALOGING.md`「MCP/模型接入 → 基建部署」边界归入 🛠 基建部署。如维护者认为应放别处可直接移动。
- 运行级如实填「待测」：未在 k8s 实测流程上验证。
