### PR TITLE
docs: 登记 dsh-data-quality

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -140,6 +140,7 @@
 | TokenLedger | [zh667/TokenLedger](https://github.com/zh667/TokenLedger) | 侧栏用量面板：把 token 归因到实际服务请求的中继站（121★，rc.8 实测 ✅） | ✅ |
 | dsh-easyrewrite | [Renzic-Stone/DSH-EasyRewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) | DSH Web 用户消息气泡内联编辑与撤回插件：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n（中/英/日）；npm `dsh-easyrewrite`（dsh.bundle.patch → cordis.patch.yml，`dsh plugin add` 一键安装） | 待测 |
 | tabbit-browser | [Tabbit-Browser/dsh-plugin](https://github.com/Tabbit-Browser/dsh-plugin) | 让 DSH Agent 通过 Tabbit 浏览器自带的 `tabbit-cli`（任务隔离的 Playwright CLI）控制真实网页、复用真实登录态，完成网页自动化、信息提取、QA 与基准测试；bundle 随安装自动注册 `tabbit-browser` skill（持久化任务空间、locator 与等待、截图、回执与恢复）+ `tabbit_browser_install` 环境预检工具（要求正式版 ≥ 1.9.0，缺失或过低时按系统地区后台下载国内 `tabbit.com` / 国际 `tabbit.ai` 对应安装包到 Downloads 并通知绝对路径）；MIT，npm `tabbit-browser` | 待测 |
+| dsh-data-quality | [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域；npm `dsh-data-quality` 已发布 0.1.3 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-data-quality |
| 仓库 | https://github.com/PerryLink/dsh-data-quality |
| **分类** | 🔌 单插件（功能分类：🗂 文件数据） |
| 一句话说明 | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-data-quality`（未使用 `@dsh-external/*`：尚未获得 dsh-external 维护权限，按本仓库 README「给插件开发者」约定，使用自己有权控制的命名空间，获得维护权限后再迁移）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`dependencies` / `peerDependencies`；官方 `@deepseek-ai/*` 以 `peerDependencies` 声明）
- [x] 自检结果：本会话未在本地执行 `dsh --profile headless --patch ... "hi"`（本地无 DEEPSEEK_API_KEY，无法跑通模型回路，故不伪造「加载成功」）。等效加载证据来自仓库自身：`ci.yml`（3 OS × Node 22/24，含真实 dsh CLI profile 挂载冒烟）与 `scripts/loader-runner.mjs`（真实 Loader 组合 + 无 key 三工具链），详见仓库 README「Development」一节。

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-data-quality | [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域 | 待测 |

## 备注

运行级填「待测」：未走本仓库 k8s 运行级实测流程，等待雷达自动扫描判定。
