### PR TITLE
docs: 登记 Blue

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -258,4 +258,5 @@
 | dsh-budget | [PerryLink/dsh-budget](https://github.com/PerryLink/dsh-budget) | 成本治理：按模型/会话/天聚合 token 与费用计量，会话/日/月预算上限 + 阈值告警（桌面通知 + webhook）与超限 alert/block/degrade 策略，碳足迹估算、分模型延迟基准、Settings 预算页与 /budget 命令 | 待测 |
 | dsh-defend | [PerryLink/dsh-defend](https://github.com/PerryLink/dsh-defend) | 注入/越狱/密钥泄露检测 + 危险删除门禁：Aho-Corasick 引擎在用户消息、工具参数、工具结果三处按 allow/ask/block 拦截（脱敏 defend/detection 审计事件、defend_report 工具、/defend 命令），并拒绝工作区外的递归删除命令 | 待测 |
 | dsh-sessions-manager | [TOBYCAI/dsh-sessions-manager](https://github.com/TOBYCAI/dsh-sessions-manager) | 统一「会话管理」面板：归档/恢复/彻底删除/跨工作区移动/批量多选/工作区标签 + 每条会话详情（磁盘占用、轮次/步骤/消息、工具使用、write/edit 文件、血统）；卡片操作收敛为 ⋯ 菜单 | 待测 |
+| Blue | [dsh-blue/blue](https://github.com/dsh-blue/blue) | 插件树式终端界面（TUI）：流式 markdown 会话流、工具卡片、模糊命令补全、主题热切换与 /btw 旁路提问，每个界面组件都是可热替换的 Cordis 插件；npm `@dsh-blue/blue`（`rc` 线，`dsh plugin --profile blue add @dsh-blue/blue@rc` 安装），双语文档站 dsh-blue.dev | 待测 |
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | Blue |
| 仓库 | https://github.com/dsh-blue/blue |
| **分类** | 🔌 Web UI 增强 |
| 一句话说明 | 插件树式终端界面（TUI）：流式 markdown 会话流、工具卡片、模糊命令补全、主题热切换与 /btw 旁路提问，每个界面组件都是可热替换的 Cordis 插件 |

## 自检清单

- [ ] package.json `name` 使用 `@dsh-external/*` scope —— **未勾选，如实说明**：包名在自有组织 scope `@dsh-blue/*` 下（未占用 `@deepseek-ai/*` 保留命名空间；npm 已发布 `@dsh-blue/blue`）。若登记要求必须 `@dsh-external/*`，请告知，我们评估是否接受该条为硬性条件。
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（Cordis 与 dsh-\* 服务包按宿主插件模型声明为 peerDependencies，镜像为 devDependencies；bundle 另携带 tsdown 构建产物，npm 安装即用）
- [x] 已按自检三步实测通过

**自检结果**：装机与加载级验证为该仓库 CI 的一部分——真实进程冒烟（`pnpm smoke:happy` / `smoke:pty`：真 dsh CLI + 真 PTY 起完整插件树）在 CI 常绿；另有 scratch DSH_HOME 的 npm 装机验证（`dsh plugin --profile blue add @dsh-blue/blue@rc` → boot → TUI 存活）与真实任务 dogfood 记录（docs/history/blue-dogfood-r5.md）。安装命令：`dsh plugin --profile blue add @dsh-blue/blue@rc`（预览线走 `rc` dist-tag，`latest` 留给稳定线）。

## 改动内容

PLUGINS.md 追加一行（追加在表尾）：

| 插件 | 仓库 | 说明 |
|---|---|---|
| Blue | [dsh-blue/blue](https://github.com/dsh-blue/blue) | 插件树式终端界面（TUI）：流式 markdown 会话流、工具卡片、模糊命令补全、主题热切换与 /btw 旁路提问；每个界面组件都是可热替换的 Cordis 插件 |

## 备注

- manifest 在 monorepo 子包 `packages/bundle/blue/package.json`（`dsh.bundle.patch` → `./cordis.patch.yml`），npm 包 `repository.directory` 指回该子包
- 双语文档站：https://dsh-blue.dev · MIT
- 欢迎 k8s 实测：若需要任何装机配合（profile 名、安装 spec）随时说