### PR TITLE
PLUGINS.md: 登记 beijingwahw/dsh-nuke-plugin（单插件，待测）

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -259,3 +259,4 @@
 | dsh-defend | [PerryLink/dsh-defend](https://github.com/PerryLink/dsh-defend) | 注入/越狱/密钥泄露检测 + 危险删除门禁：Aho-Corasick 引擎在用户消息、工具参数、工具结果三处按 allow/ask/block 拦截（脱敏 defend/detection 审计事件、defend_report 工具、/defend 命令），并拒绝工作区外的递归删除命令 | 待测 |
 | dsh-sessions-manager | [TOBYCAI/dsh-sessions-manager](https://github.com/TOBYCAI/dsh-sessions-manager) | 统一「会话管理」面板：归档/恢复/彻底删除/跨工作区移动/批量多选/工作区标签 + 每条会话详情（磁盘占用、轮次/步骤/消息、工具使用、write/edit 文件、血统）；卡片操作收敛为 ⋯ 菜单 | 待测 |
 
+| dsh-nuke-plugin | [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) | 事务化强力卸载引擎：validate/preview/execute/undo 四段式 + Saga 回滚、WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演（成功率/期望回收/最脆弱步骤）；21 工具 222 测试 MIT | 待测 |


### PR DESCRIPTION
在「🔌 单插件」分类追加一行登记。

**自荐说明**：解决「插件装卸残留越积越多、手工清理怕误删、脚本清理不可逆」的问题。适合频繁装卸插件的 DSH 用户。每个破坏性动作走 validate/preview/execute/undo 四段式并带 Saga 回滚；WAL 预写日志 + 备份区实现崩溃自恢复；hash chain 审计日志可验证完整性；内容寻址硬链接去重；贝叶斯先知推演事务成功率与期望回收。21 个工具、222 个测试、MIT。

**最低收录条件自检**：
- [x] 仓库公开可访问，已带 `dsh-plugin` topic
- [x] 根目录合法 `package.json`（非空 name）
- [x] `main` 入口 + `dsh` 集成声明（dsh.bundle manifest，`dsh plugin add beijingwahw/dsh-nuke-plugin --profile web` 可安装）
- [x] README 说明做什么/如何安装/如何卸载/最小示例
- [x] 运行时依赖在 dependencies 中显式声明
- [x] MIT 许可证

**测试环境与结果**：本地 vitest 222/222 通过；未做容器运行级实测，故运行级如实标注「待测」。