### PR TITLE
docs: 登记 dsh-session-repair

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -149,6 +149,7 @@
 | dsh-fast | [PerryLink/dsh-fast](https://github.com/PerryLink/dsh-fast) | 只读性能诊断：会话加载/恢复耗时、spill 命中计数、压缩次数与触发、上下文注入体量（AGENTS.md/技能/工具 schema 的 token 占比）与 LLM 缓存命中率，经 /fast 命令与 fast_report 工具呈现，异步采样不阻塞模型路径；npm `dsh-fast` 0.1.3 | 待测 |
 | dsh-data-quality | [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域；npm `dsh-data-quality` 已发布 0.1.3 | 待测 |
 | meow-cachebilling | [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) | 喵账单：点开输入框旁的上下文圆环即见本轮账单——缓存命中/未命中/输出各花多少钱（¥），官方峰谷价与模型分价自动判定，仅 DeepSeek 官方 API 显示；lib 随 git 发布零构建直装 | 待测 |
+| dsh-session-repair (Zn-Dk) | [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-session-repair |
| 仓库 | https://github.com/Zn-Dk/dsh-session-repair |
| **分类** | 🔌 Web UI 增强（运行级判定为「待测」，见下方说明） |
| 一句话说明 | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用自有命名空间 `dsh-session-repair`（未占用 `@deepseek-ai/*` 保留命名空间；未使用 `@dsh-external/*` scope）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`peerDependencies`：`@deepseek-ai/cordis`、`@deepseek-ai/dsh-llm`、`@deepseek-ai/dsh-skill`）
- [x] 已按自检三步实测通过：`dsh plugin --profile web add dsh-session-repair` 成功安装为 `dsh-session-repair@0.5.3`（profile 锁文件通过 supply-chain policies，peer deps 仅出现非阻断 WARN）

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-session-repair | https://github.com/Zn-Dk/dsh-session-repair | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair |

## 备注

- 本仓库已存在同名插件 `Equinox7379/dsh-session-repair`（不同作者/不同仓库），本 PR 为 `Zn-Dk/dsh-session-repair` 的独立登记，二者同名不同源，请勿合并为一条。
- 分类用预归类器 `python3 scripts/classify.py "dsh-session-repair" "<描述>"` 命中「面板」→ 🔌 Web UI 增强；若维护者认为更贴近运行级修复工具，可直接改为合适类目。
- 本插件已向 `awesome-dsh-plugin/awesome-dsh-plugin` 提交收录 PR（category: session），并已向 `0xsline/awesome-deepseek-harness` 提交 PR #478（Runtime & Operations），三个渠道互相独立、不冲突。