### PR TITLE
docs: register meow-cachebilling (per-round cache bill in the context meter panel)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -147,6 +147,7 @@
 | dsh-mask | [PerryLink/dsh-mask](https://github.com/PerryLink/dsh-mask) | PII 脱敏中间件：在模型边界前把姓名/电话/邮箱/身份证/银行卡/密钥/地址替换为占位符，展示层还原，明文绝不入会话日志；/mask 命令 + mask_test 工具；npm dsh-mask 0.1.4 已发布 | 待测 |
 | dsh-fast | [PerryLink/dsh-fast](https://github.com/PerryLink/dsh-fast) | 只读性能诊断：会话加载/恢复耗时、spill 命中计数、压缩次数与触发、上下文注入体量（AGENTS.md/技能/工具 schema 的 token 占比）与 LLM 缓存命中率，经 /fast 命令与 fast_report 工具呈现，异步采样不阻塞模型路径；npm `dsh-fast` 0.1.3 | 待测 |
 | dsh-data-quality | [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域；npm `dsh-data-quality` 已发布 0.1.3 | 待测 |
+| meow-cachebilling | [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) | 喵账单：点开输入框旁的上下文圆环即见本轮账单——缓存命中/未命中/输出各花多少钱（¥），官方峰谷价与模型分价自动判定，仅 DeepSeek 官方 API 显示；lib 随 git 发布零构建直装 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
按 contributing 约定在「🔌 单插件」表格登记 [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling)。仓库已带 `dsh-plugin` topic、有 GitHub 简介、声明 dsh.bundle manifest。

喵账单：点开输入框旁的上下文圆环即见本轮账单——缓存命中/未命中/输出各花多少钱（¥），官方峰谷价与模型分价自动判定，仅 DeepSeek 官方 API 显示；lib 随 git 发布零构建直装，`dsh plugin --profile web add meow-cachebilling`。