### PR TITLE
Add dsh-better-stats (enhanced composer stats strip)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -22,6 +22,7 @@
 | dsh-event-auditor | [qing3a/dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | Harness 事件流审计面板：观察事件类型/分发模式/计数/最近事件，settings 热改 + /audit 会话命令；已用 mock-llm 运行时验证（74 事件/12 waterfall） | ✅ |
 | dsh-spend | [nonewind/dsh-spend](https://github.com/nonewind/dsh-spend) | Token 用量统计与预计费用：右下角悬浮窗，按模型/按天/按会话多维聚合，内置供应商知识库自动识别计费计划（web bundle） | ✅ |
 | dsh-tokstat | [kongjianguan/dsh-tokstat](https://github.com/kongjianguan/dsh-tokstat) | DSH 使用量与性能统计：设置页「统计」面板（概览/模型/会话/请求，TTFT/TPS/Tokens/成本）+ Python TUI；Node half + client web bundle | ✅ |
+| dsh-better-stats | [null5069/dsh-better-stats](https://github.com/null5069/dsh-better-stats) | DSH Web 输入框下方增强统计条：官方人民币计价（峰谷分时、官方价目自动同步）、多模型分账、实时计时、子代理树合并、余额直连、预算预警、流式成本估算；host + client web bundle，npm `dsh-better-stats` | 待测 |
 | dsh-tray | [qing3a/dsh-tray](https://github.com/qing3a/dsh-tray) | DeepSeek Harness Windows 系统托盘插件（trayicon exe 宿主，无 native 编译）；菜单/通知/headless 降级，双 profile 已验证 | ✅ |
 | dsh-lan-access | [Leon0555/dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) | 局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃），npm 可装 | ✅ |
 | dsh-full-remote | [JUANWANG-BUAA/dsh-full-remote](https://github.com/JUANWANG-BUAA/dsh-full-remote) | 令牌反向代理：改写 Host/Origin，远程恢复 `settings.*`/`credentials.*`/`host.listDirectory`（通用隧道会 403）；一次性扫码邀请、按设备会话；npm `dsh-full-remote` | ✅ |


### PR DESCRIPTION
## 新增：dsh-better-stats

在 🔌 单插件 表格中登记 [null5069/dsh-better-stats](https://github.com/null5069/dsh-better-stats)（插在 dsh-tokstat 之后，与 dsh-spend / dsh-tokstat 组成统计簇）。

**功能（客观描述）：**
- DSH Web 输入框下方增强统计条（host + client web bundle）
- 官方人民币计价：峰谷分时（高峰 ×2）、官方价目 6h 自动同步、按模型分账
- 实时 LLM/工具计时、首 token / tok/s、缓存分桶与命中率
- 子代理树（agent-team）合并结算、流式成本估算
- DeepSeek 余额直连（凭据走 host）、预算/余额两档预警
- 中英双语，npm `dsh-better-stats` v0.1.15 一键安装，MIT，零运行时依赖

**状态说明：** 运行级填「待测」——尚未经本雷达实测，实测通过后请升级 ✅。

仓库已打 `dsh-plugin` topic，README 含安装/卸载/许可证。