### PR TITLE
docs: 登记 dsh-humanize

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -153,6 +153,7 @@
 | meow-cachebilling | [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) | 喵账单：点开输入框旁的上下文圆环即见本轮账单——缓存命中/未命中/输出各花多少钱（¥），官方峰谷价与模型分价自动判定，仅 DeepSeek 官方 API 显示；lib 随 git 发布零构建直装 | 待测 |
 | dsh-session-repair (Zn-Dk) | [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 | 待测 |
 | dsh-rss-daily | [shangjian2023/dsh-rss-daily](https://github.com/shangjian2023/dsh-rss-daily) | 每日定时抓取 46 个精选 RSS 源，由 dsh 内已配置的模型编辑成新闻简报，经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify；错过时段自动补跑；Web 面板 + rss_daily agent 工具；npm `dsh-rss-daily` | 待测 |
+| dsh-humanize | [Guard42/dsh-humanize](https://github.com/Guard42/dsh-humanize) | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层（不写自定义会话事件） | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-humanize |
| 仓库 | https://github.com/Guard42/dsh-humanize |
| **分类** | 🤖 Agent 能力 |
| 一句话说明 | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层 |

> 分类依据：已运行 `scripts/classify.py "dsh-humanize" "<一句话说明>"`，输出「建议分类: 🤖 Agent 能力（命中规则: agent）」。

## 自检清单

- [x] package.json `name` 未占用 `@deepseek-ai/*` 保留命名空间 —— 本插件为 git-bundle 直装（`dsh plugin add github:Guard42/dsh-humanize`），不经 npm 分发，故未注册任何 npm scope；如维护者要求迁移到 `@dsh-external/*` 再发布，愿意配合
- [x] 仓库已打 `dsh-plugin` topic（另有 `agent-preset` / `dsh-preset` 等）
- [x] 已在 fork Settings → General 开启 **Allow edits and access to secrets by maintainers**，本 PR 允许维护者 rebase
- [x] 运行时依赖：零第三方依赖（仅 node: 内置模块），无需额外声明
- [x] 自检三步实测：

```
$ dsh plugin add github:Guard42/dsh-humanize
→ bundle installer bridge 在宿主启动时把 agent preset 同步进 DSH preset root（8 文件，含哈希戳防覆盖）
$ 以 humanize preset 新开会话
→ 15 个 flow_* 工具加载正常；flow_draft → flow_check → flow_lock → flow_review_prepare → flow_review_decide → flow_run 全链路可用
$ 回归验证
→ 冒烟测试套件全绿（kernel / store / tool-flow module shape / bundle installer）；v0.1.1 修复了 ≤0.1.0 向会话日志写自定义事件导致 SessionFormatUnsupportedError 的缺陷，现完全兼容原版 harness 持久层
```

## 改动内容

PLUGINS.md「🔌 单插件」表格追加一行：

```markdown
| dsh-humanize | [Guard42/dsh-humanize](https://github.com/Guard42/dsh-humanize) | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层（不写自定义会话事件） | 待测 |
```

## 备注

- **发现一处死链供参考**：PLUGINS-ALL.md 第 1632 行现有 `[可用] dsh-humanize → zevorn/dsh-humanize`，该仓库现已 404（匿名与认证 API 均确认）。与本 PR 的 Guard42/dsh-humanize 是不同项目，建议雷达下个周期清理该 tombstone 时一并处理，避免同名混淆。
- MIT 协议；CI（ubuntu/windows 三检查矩阵）全绿；Release v0.1.1 已发布。