### PR TITLE
docs: 登记 dsh-worktree

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -10,6 +10,7 @@
 
 | 插件 | 仓库 | 说明 | 运行级 |
 |---|---|---|---|
+| dsh-worktree | [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) | DSH Web 极简 Git worktree 管理：一个按钮和一个对话框创建任务分支 worktree，并直接打开为 DSH Workspace；npm `@alpacachen/dsh-simple-worktree` 1.0.2 | 待测 |
 | dsh-session-pin | [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 会话与工作区置顶（双面 host+client）：行级图钉与换色、会话头开关、已置顶面板、持久化 settings 命名空间；0.4.0 再加会话导航组织器——Pin 分组（boards）、标签与保存视图、会话健康摘要（只读脱敏）与 /goto 模糊跳转；全部浏览器本地零网络 | 待测 |
 | dsh-agentfuse-plugin | [MkaliezZ/dsh-agentfuse-plugin](https://github.com/MkaliezZ/dsh-agentfuse-plugin) | 确定性 fail-closed 工具调用授权门：allow/block/ask 策略门 + 审批链延后 + agentfuse-evidence-schema 证据；配 dsh-policy-test 闭环回归；已获本雷达运行级 [可用] 判定 | ✅ |
 | dsh-evidence-task-board | [MkaliezZ/dsh-evidence-task-board](https://github.com/MkaliezZ/dsh-evidence-task-board) | 持久化确定性任务状态原语（创建/状态/证据转移）；npm 包 @mkaliezz/dsh-task-board | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-worktree |
| 仓库 | https://github.com/alpacachen/dsh-worktree |
| **分类** | 💻 编码开发 |
| 一句话说明 | DSH Web 极简 Git worktree 管理：创建任务分支 worktree，并直接打开为 DSH Workspace。 |

## 自检清单

- [x] npm 包使用作者控制的 `@alpacachen/*` scope，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已添加 `dsh-plugin` topic
- [x] Allow edits from maintainers
- [x] 所有运行时依赖已在 `dependencies` / `peerDependencies` 声明
- [x] v1.0.2 已通过 build、typecheck、10 项单元测试、client bundle 与 package contents 检查
- [x] 已发布 npm 包 `@alpacachen/dsh-simple-worktree@1.0.2`

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-worktree | https://github.com/alpacachen/dsh-worktree | DSH Web 极简 Git worktree 管理：一个按钮和一个对话框创建任务分支 worktree，并直接打开为 DSH Workspace；npm `@alpacachen/dsh-simple-worktree` 1.0.2 |

## 备注

仓库也已提交到 awesome-dsh-plugin 社区目录；此 PR 用于登记到本仓库的独立雷达与运行级测试队列。