### PR TITLE
docs: 登记 dsh-rss-daily

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -150,6 +150,7 @@
 | dsh-data-quality | [PerryLink/dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) | 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 三个模型工具 + 冻结的跨插件 verifyCitations 引用核验契约，报告持久化到 data_quality 存储域；npm `dsh-data-quality` 已发布 0.1.3 | 待测 |
 | meow-cachebilling | [Phant0Meow/dsh-meow-cachebilling](https://github.com/Phant0Meow/dsh-meow-cachebilling) | 喵账单：点开输入框旁的上下文圆环即见本轮账单——缓存命中/未命中/输出各花多少钱（¥），官方峰谷价与模型分价自动判定，仅 DeepSeek 官方 API 显示；lib 随 git 发布零构建直装 | 待测 |
 | dsh-session-repair (Zn-Dk) | [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 | 待测 |
+| dsh-rss-daily | [shangjian2023/dsh-rss-daily](https://github.com/shangjian2023/dsh-rss-daily) | 每日定时抓取 46 个精选 RSS 源，由 dsh 内已配置的模型编辑成新闻简报，经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify；错过时段自动补跑；Web 面板 + rss_daily agent 工具；npm `dsh-rss-daily` | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-rss-daily |
| 仓库 | https://github.com/shangjian2023/dsh-rss-daily |
| **分类** | 📰 资讯与内容(如分类不当请指正,13 类中未找到更贴切项) |
| 一句话说明 | 每日定时抓取 46 个精选 RSS 源,由 dsh 内已配置的模型编辑成新闻简报,经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify,错过时段自动补跑 |

## 自检清单

- [ ] package.json `name` 使用 `@dsh-external/*` scope —— **未满足,如实说明**:包已以未 scoped 名 `dsh-rss-daily` 发布 npm,且已被 awesome-dsh-plugin/awesome-dsh-plugin 收录(PR #2760 已合并);如必须迁移 `@dsh-external/*` scope 我可以改,但会与现有收录/用户安装名不一致,请维护者定夺
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已勾选 Allow edits from maintainers
- [x] 所有运行时依赖已声明(feedparser 为 Python 端依赖,文档已注明)
- [x] 已按自检三步实测通过:在 dsh 0.1.1-rc.2 上以 `--patch` 方式加载并跑通完整链路 (fetch 9 源 67 候选 → `ctx.llm` 真模型编辑 8 条 → webhook 投递 → confirm 落盘),详见仓库 README 的 Testing 一节

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-rss-daily | https://github.com/shangjian2023/dsh-rss-daily | 每日定时抓取 46 个精选 RSS 源,模型编辑成简报,webhook 推送到 IM 渠道 |

## 备注

插件带 Web 设置面板、对话内插播(原生 MarkdownText 渲染)与 `rss_daily` agent 工具;LLM 失败自动降级规则版;TLS 证书校验默认开启。分类请以贵库 taxonomy 为准,PR 里可改。