### PR TITLE
docs: 登记 dsh-session-explorer

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -11,6 +11,7 @@
 | 插件 | 仓库 | 说明 | 运行级 |
 |---|---|---|---|
 | dsh-session-pin | [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 会话与工作区置顶（双面 host+client）：行级图钉与换色、会话头开关、已置顶面板、持久化 settings 命名空间；0.4.0 再加会话导航组织器——Pin 分组（boards）、标签与保存视图、会话健康摘要（只读脱敏）与 /goto 模糊跳转；全部浏览器本地零网络 | 待测 |
+| dsh-session-explorer | [Zn-Dk/dsh-session-explorer](https://github.com/Zn-Dk/dsh-session-explorer) | 会话消息级全文检索浏览器：FTS5 trigram 按消息检索（用户/助手/系统注入/工具，可按类型筛选），fork/续接会话结果自动去重，只读上下文预览自动滚动定位、一键跳转真实会话，增量/全量重建索引 + 健康检查，中英双语跟随 Host locale | 待测 |
 | dsh-agentfuse-plugin | [MkaliezZ/dsh-agentfuse-plugin](https://github.com/MkaliezZ/dsh-agentfuse-plugin) | 确定性 fail-closed 工具调用授权门：allow/block/ask 策略门 + 审批链延后 + agentfuse-evidence-schema 证据；配 dsh-policy-test 闭环回归；已获本雷达运行级 [可用] 判定 | ✅ |
 | dsh-evidence-task-board | [MkaliezZ/dsh-evidence-task-board](https://github.com/MkaliezZ/dsh-evidence-task-board) | 持久化确定性任务状态原语（创建/状态/证据转移）；npm 包 @mkaliezz/dsh-task-board | 待测 |
 | dsh-test-normalizer | [MkaliezZ/dsh-test-normalizer](https://github.com/MkaliezZ/dsh-test-normalizer) | pytest / Vitest / Jest / Cargo 测试结果归一化为稳定结构；npm 包 @mkaliezz/dsh-test-runner | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-session-explorer |
| 仓库 | https://github.com/Zn-Dk/dsh-session-explorer |
| **分类** | 🔌 Web UI 增强（会话消息检索面板；classify.py 命中「📡 消息通讯」但实为 IM bot 类目，本插件是会话搜索面板，故人工改归 Web UI 增强，详见备注） |
| 一句话说明 | 会话消息级全文检索浏览器：FTS5 trigram 按消息检索（用户/助手/系统注入/工具，可按类型筛选），fork/续接会话结果自动去重，只读上下文预览自动滚动定位、一键跳转真实会话，增量/全量重建索引 + 健康检查，中英双语跟随 Host locale |

## 自检清单

- [x] package.json name 使用 dsh-session-explorer（未占用 @deepseek-ai/* 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 fork Settings → General 开启 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（peerDependencies: @deepseek-ai/dsh-home-paths、zod）
- [x] 已按自检三步实测通过：

```bash
# 1. npm 已发布且本机 profile 安装验证（GUI 真机使用中）
npm view dsh-session-explorer version   # 0.3.0
# 2. 本机 dsh web 加载无报错（侧栏入口 + 检索面板 + 重建索引均 GUI 验证通过）
# 3. 41 个单元测试全绿（node --import tsx --test test/*.test.ts）
```

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-session-explorer | [Zn-Dk/dsh-session-explorer](https://github.com/Zn-Dk/dsh-session-explorer) | 会话消息级全文检索浏览器：FTS5 trigram 按消息检索（用户/助手/系统注入/工具，可按类型筛选），fork/续接会话结果自动去重，只读上下文预览自动滚动定位、一键跳转真实会话，增量/全量重建索引 + 健康检查，中英双语跟随 Host locale |

## 备注

- 分类说明：预归类器输出「📡 消息通讯」（描述含「消息」命中 IM 规则），但本插件是**会话历史检索面板**（Web UI），非 IM/通知通道，按边界归属归「🔌 Web UI 增强」；若维护者认为「🗂 文件数据（索引/检索）」更贴切可直接改。
- 插件已打 dsh-plugin topic，自动雷达应已收录，本 PR 为人工精选加速登记。