### PR TITLE
docs: 登记 dsh-rewind

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -277,3 +277,4 @@
 | Blue | [dsh-blue/blue](https://github.com/dsh-blue/blue) | 插件树式终端界面（TUI）：流式 markdown 会话流、工具卡片、模糊命令补全、主题热切换与 /btw 旁路提问，每个界面组件都是可热替换的 Cordis 插件；npm `@dsh-blue/blue`（`rc` 线，`dsh plugin --profile blue add @dsh-blue/blue@rc` 安装），双语文档站 dsh-blue.dev | 待测 |
 
 | dsh-nuke-plugin | [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) | 事务化强力卸载引擎：validate/preview/execute/undo 四段式 + Saga 回滚、WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演（成功率/期望回收/最脆弱步骤）；21 工具 222 测试 MIT | 待测 |
+| dsh-rewind | [SiriLee/dsh-rewind](https://github.com/SiriLee/dsh-rewind) | DSH Web 同窗口原地回退（Claude Code /rewind 语义）：每条用户消息旁 ↶ 按钮把模型上下文截断回任意一条消息，可选 Claude Code 风格文件回滚（磁盘持久化 before 备份）；npm `dsh-rewind-plugin`，`dsh plugin add` 一键安装 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-rewind |
| 仓库 | https://github.com/SiriLee/dsh-rewind |
| **分类** | 🧠 记忆增强（人工复核：classify.py 因 "restore" 误命中 store；会话回退属历史召回） |
| 一句话说明 | DSH Web 同窗口原地回退（Claude Code /rewind 语义）：每条用户消息旁 ↶ 按钮把模型上下文截断回任意一条消息，可选 Claude Code 风格文件回滚（磁盘持久化 before 备份） |

## 自检清单

- [x] package.json name 使用 `dsh-rewind-plugin`（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 Allow edits from maintainers
- [x] 所有运行时依赖已声明
- [x] 自检结果：`dsh plugin --profile headless --patch ... add dsh-rewind-plugin` 加载成功，14 测试文件 / 154 用例全绿

## 改动内容

- `PLUGINS.md`：🔌 单插件 表追加 dsh-rewind 一行