### PR TITLE
docs: 登记 dsh-edit-approval

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -287,4 +287,5 @@
 | Blue | [dsh-blue/blue](https://github.com/dsh-blue/blue) | 插件树式终端界面（TUI）：流式 markdown 会话流、工具卡片、模糊命令补全、主题热切换与 /btw 旁路提问，每个界面组件都是可热替换的 Cordis 插件；npm `@dsh-blue/blue`（`rc` 线，`dsh plugin --profile blue add @dsh-blue/blue@rc` 安装），双语文档站 dsh-blue.dev | 待测 |
 
 | dsh-nuke-plugin | [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) | 事务化强力卸载引擎：validate/preview/execute/undo 四段式 + Saga 回滚、WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演（成功率/期望回收/最脆弱步骤）；21 工具 222 测试 MIT | 待测 |
+| dsh-edit-approval | [SiriLee/dsh-edit-approval](https://github.com/SiriLee/dsh-edit-approval) | 写文件/工具调用前的逐处审批门：write/edit/stream 操作显示红绿行级 diff 后再放行，bash 命令审批（默认关）+ 可配置门控；npm `dsh-edit-approval`，`dsh plugin add` 一键安装 | 待测 |
 | dsh-rewind | [SiriLee/dsh-rewind](https://github.com/SiriLee/dsh-rewind) | DSH Web 同窗口原地回退（Claude Code /rewind 语义）：每条用户消息旁 ↶ 按钮把模型上下文截断回任意一条消息，可选 Claude Code 风格文件回滚（磁盘持久化 before 备份）；npm `dsh-rewind-plugin`，`dsh plugin add` 一键安装 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-edit-approval |
| 仓库 | https://github.com/SiriLee/dsh-edit-approval |
| **分类** | 💻 编码开发（classify.py 命中 diff） |
| 一句话说明 | 写文件/工具调用前的逐处审批门：write/edit/stream 操作显示红绿行级 diff 后再放行，bash 命令审批（默认关）+ 可配置门控 |

## 自检清单

- [x] package.json name 使用 `dsh-edit-approval`（未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已在 PR 页面勾选 Allow edits from maintainers
- [x] 所有运行时依赖已声明
- [x] 自检结果：`dsh plugin --profile web add dsh-edit-approval` 加载成功

## 改动内容

- `PLUGINS.md`：🔌 单插件 表追加 dsh-edit-approval 一行