### PR TITLE
docs: 登记 dsh-forge

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -154,6 +154,7 @@
 | dsh-session-repair (Zn-Dk) | [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 | 待测 |
 | dsh-rss-daily | [shangjian2023/dsh-rss-daily](https://github.com/shangjian2023/dsh-rss-daily) | 每日定时抓取 46 个精选 RSS 源，由 dsh 内已配置的模型编辑成新闻简报，经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify；错过时段自动补跑；Web 面板 + rss_daily agent 工具；npm `dsh-rss-daily` | 待测 |
 | dsh-humanize | [Guard42/dsh-humanize](https://github.com/Guard42/dsh-humanize) | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层（不写自定义会话事件） | 待测 |
+| dsh-forge | [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) | 自建 Gitea / Forgejo 的只读工具，走两者共用的 REST API：实例版本、仓库列表、议题与 PR 搜索和读取、PR diff 与变更文件，以及 Actions 运行、任务与纯文本日志；11 个工具全部只读，npm `@maxhsu/dsh-forge` 0.3.3 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-forge |
| 仓库 | https://github.com/maxmilian/dsh-forge |
| **分类** | 💻 编码与生产力 |
| 一句话说明 | 自建 Gitea / Forgejo 的只读工具：实例版本、仓库列表、议题与 PR 搜索和读取、PR diff 与变更文件，以及 Actions 运行、任务与纯文本日志。 |

登记在 `PLUGINS.md` 的「🔌 单插件」表格，一行，运行级填「待测」（由本仓库的实测管线判定，未自行填写结论）。

## 自检说明

- [x] 仓库已打 `dsh-plugin` topic（另有 `deepseek-harness` / `gitea` / `forgejo`）
- [x] 所有运行时依赖已声明：官方 `@deepseek-ai/*` 走 `peerDependencies`（`@deepseek-ai/dsh-tools` 用 `^0.1.0-rc.6 || ^0.1.1-rc.2`，显式包含 0.1.1 预发布分支，避免 node-semver 静默排除）
- [x] 已发布到 npm（`@maxhsu/dsh-forge` 0.3.3），预构建安装免 `allowBuilds`；GitHub Release 另附稳定文件名 tarball
- [x] 本地已实测：`bun pm pack` 后 `dsh plugin --profile web add <tarball>`，`--dump-config` 可见 `forge-tools`
- [ ] package.json 使用 `@dsh-external/*` scope —— **未采用**：该 scope 属于官方生态组织，本插件为个人维护，发布在 `@maxhsu` 个人 scope 下，未占用 `@deepseek-ai/*` 保留命名空间

MIT，11 个工具在 v0.3 全部只读，CI 含针对 Gitea 与 Forgejo 真实实例的集成测试。