### PR TITLE
docs: 登记 dsh-sonarqube

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -215,6 +215,7 @@
 ## ❓ 未分类
 
 <!-- 新增条目示例（复制下面一行修改后插入对应分类表格末尾）：
+| dsh-sonarqube | [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) | SonarQube Community Build Web API 的只读工具：实例状态、分支或 PR 的质量阈、议题与安全热点搜索、单个热点详情，以及覆盖率、重复率或调用方指定的度量项；6 个工具全部只读，npm `dsh-sonarqube` 0.1.0 | 待测 |
 | dsh-email | [STARDUSTLC666/dsh-email](https://github.com/STARDUSTLC666/dsh-email) | 邮件工具插件：IMAP/SMTP 收/发/搜/列文件夹/附件下载（email_list/read/search/send/folders/attachment），内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，支持多账号与连接复用，发信默认走审批门；纯 Node 全平台 | 待测 |
 | dsh-calendar | [STARDUSTLC666/dsh-calendar](https://github.com/STARDUSTLC666/dsh-calendar) | CalDAV 日历插件：查/建/改/删/搜日程（calendar_list/create/update/delete/search），Google/iCloud/Nextcloud/自定义端点，应用专用密码 | 待测 |
 | dsh-dingtalk | [STARDUSTLC666/dsh-dingtalk](https://github.com/STARDUSTLC666/dsh-dingtalk) | 钉钉群机器人通知（dingtalk_notify/dingtalk_text），自定义机器人 webhook+加签，零运行时依赖 | ✅ |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-sonarqube |
| 仓库 | https://github.com/maxmilian/dsh-sonarqube |
| **分类** | 💻 编码与生产力 |
| 一句话说明 | SonarQube Community Build 的只读工具：实例状态、分支或 PR 的质量阈、议题与安全热点搜索、单个热点详情，以及覆盖率、重复率或调用方指定的度量项。 |

登记在 `PLUGINS.md` 的「🔌 单插件」表格，一行，运行级填「待测」。

## 自检说明

- [x] 仓库已打 `dsh-plugin` topic（另有 `deepseek-harness` / `sonarqube` / `code-quality`）
- [x] 所有运行时依赖已声明：官方 `@deepseek-ai/*` 全部走 `peerDependencies`（`@deepseek-ai/dsh-tools` 用 `^0.1.0-rc.8 || ^0.1.1-rc.2`）
- [x] 已发布到 npm（`dsh-sonarqube` 0.1.0），预构建安装免 `allowBuilds`；GitHub Release 另附稳定文件名 tarball
- [x] 本地已实测：`bun pm pack` 后 `dsh plugin --profile web add <tarball>`，`--dump-config` 可见 `dsh-sonarqube`
- [ ] package.json 使用 `@dsh-external/*` scope —— **未采用**：个人维护插件，使用未占用的 unscoped 名称 `dsh-sonarqube`，未占用 `@deepseek-ai/*` 保留命名空间

MIT，0.1 版所有工具只读（不做指派、确认、解决或重开）。实测环境为 SonarQube Community Build 26.8.0.126808；该版本不含 SECURITY_HOTSPOT 规则，因此成功读取热点的路径由 mock 测试覆盖，README 已如实说明。