### PR TITLE
docs: 登记 dsh-qingagent

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -154,6 +154,7 @@
 | dsh-session-repair (Zn-Dk) | [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 | 待测 |
 | dsh-rss-daily | [shangjian2023/dsh-rss-daily](https://github.com/shangjian2023/dsh-rss-daily) | 每日定时抓取 46 个精选 RSS 源，由 dsh 内已配置的模型编辑成新闻简报，经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify；错过时段自动补跑；Web 面板 + rss_daily agent 工具；npm `dsh-rss-daily` | 待测 |
 | dsh-humanize | [Guard42/dsh-humanize](https://github.com/Guard42/dsh-humanize) | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层（不写自定义会话事件） | 待测 |
+| dsh-qingagent | [void2anything/dsh-qingagent](https://github.com/void2anything/dsh-qingagent) | 把开源 AI 写作客户端「青简 QingAgent」接进 DSH：对话里起草改稿，右侧宣纸面板排版渲染（mermaid/drawio/表格/KaTeX），每处修改先摆在纸上供审阅、提交才落稿（opt-out：撤销不要的，其余一次提交）；10 个 qing_ 宿主工具，npm `dsh-qingagent` 0.1.46（无 install 期脚本，lib 随 git 零构建直装）；需本机运行青简桌面客户端（qingagent.com，MIT） | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-qingagent |
| 仓库 | https://github.com/void2anything/dsh-qingagent |
| **分类** | 🔌 Web UI 增强（预归类器输出：`python3 scripts/classify.py` → 建议分类 🔌 Web UI 增强，命中规则「面板」） |
| 一句话说明 | 把开源 AI 写作客户端「青简 QingAgent」接进 DSH：对话里起草改稿，右侧宣纸面板排版渲染（mermaid/drawio/表格/KaTeX），每处修改先摆在纸上供审阅、提交才落稿 |

## 自检清单（提交前逐项确认）

- [ ] package.json `name` 使用 `@dsh-external/*` scope（未占用 `@deepseek-ai/*` 保留命名空间）
  - 说明：包名为自有独立命名空间 `dsh-qingagent`（npm 已发布），未占用 `@deepseek-ai/*`，也未使用 `@dsh-external/*`——按 README「包名应使用你有权控制的命名空间；只有获得 dsh-external 维护权限的项目才应使用 @dsh-external/*」执行，故此项按字面不勾选、按实质合规。
- [x] 仓库已打 `dsh-plugin` topic（另有 dsh / dsh-plugins / deepseek-harness 等）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**
- [x] 所有运行时依赖已声明（`dependencies`：@deepseek-ai/schemastery、zod；全部 `@deepseek-ai/dsh-*` 宿主包与 react 在 `peerDependencies` 声明）
- [x] 已按自检三步实测（结果见下，含一处如实说明的不适用项）
- [x] 自检结果贴这里：

**测试环境**：WSL2（Linux 6.6.87.2）· Node v24.15.0 · npx @deepseek-ai/dsh 0.1.1-rc.2 · 一次性隔离 DSH_HOME

1. headless 装载（模板给出的命令路径）：`dsh plugin --profile headless add dsh-qingagent@latest` 成功后，`dsh --profile headless "hi"` 报
   `dsh-qingagent: pending (waiting for services: webServer, storageDomain)`
   ——本插件是 Web UI 插件，依赖 headless profile 不提供的 webServer / storageDomain 服务，属预期不适用，而非依赖缺失。
2. web profile 装载（隔离 DSH_HOME 走官方安装路径）：`dsh plugin --profile web add dsh-qingagent@latest` 后 `dsh web --port 0 --no-open` 启动无报错，输出 `dsh web: http://127.0.0.1:42741`（插件树全部激活；未激活时 boot 会如上例以 plugin tree failed to load 退出）。
3. npm 包静态核验：`npm pack dsh-qingagent@latest` → 0.1.46；`main: lib/index.js` 存在、`exports`（`.` / `./client` 等）齐全、`cordis.patch.yml` 在包内（安装时自动合并进 profile）；无 preinstall / install / postinstall lifecycle 脚本；lib/ 构建产物随包分发（github: 安装免构建）。

**未验证部分（如实说明）**：宣纸面板实际渲染与 10 个 `qing_` 工具的端到端调用，依赖本机运行青简桌面客户端（qingagent.com，MIT）；本次测试环境未运行该客户端，未做端到端验证，以上仅为加载级结论。

## 改动内容

PLUGINS.md「🔌 单插件」表末追加一行（列结构按现有表格含「运行级」列，填「待测」）：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-qingagent | [void2anything/dsh-qingagent](https://github.com/void2anything/dsh-qingagent) | 把开源 AI 写作客户端「青简 QingAgent」接进 DSH：对话里起草改稿，右侧宣纸面板排版渲染（mermaid/drawio/表格/KaTeX），每处修改先摆在纸上供审阅、提交才落稿（opt-out：撤销不要的，其余一次提交）；10 个 qing_ 宿主工具，npm `dsh-qingagent` 0.1.46（无 install 期脚本，lib 随 git 零构建直装）；需本机运行青简桌面客户端（qingagent.com，MIT） | 待测 |

## 备注

- 硬依赖：需本机运行青简桌面客户端（qingagent.com，开源 MIT），插件经本地端口与其通信；雷达做运行级实测时，容器内无该客户端预计只能到加载级。
- 仓库昨日已补 `dsh-plugin` / `dsh` / `dsh-plugins` topic 与 LICENSE（Apache-2.0，GitHub 已识别 SPDX），若自动管线恢复应能被扫描收录；本 PR 为人工登记。
- 10 个宿主工具（`qing_` 前缀）：write_draft / edit_draft / read_draft / review_commit / list_docs / focus_doc / annotate / export / list_materials / read_material。
