### PR TITLE
Add zhengjy01/dsh-task-dispatcher (TickTick daily task dispatcher)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -215,6 +215,7 @@
 ## ❓ 未分类
 
 <!-- 新增条目示例（复制下面一行修改后插入对应分类表格末尾）：
+| dsh-task-dispatcher | [zhengjy01/dsh-task-dispatcher](https://github.com/zhengjy01/dsh-task-dispatcher) | 滴答清单任务派发器：按间隔拉取今天到期任务（有变化才通知 flomo+macOS），可选自动执行（每任务一个 headless 会话）、执行会话工作区选择、dispatcher_report flomo 汇总工具与 Web 任务看板；npm `dsh-task-dispatcher` 0.1.0 | 待测 |
 | dsh-sonarqube | [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) | SonarQube Community Build Web API 的只读工具：实例状态、分支或 PR 的质量阈、议题与安全热点搜索、单个热点详情，以及覆盖率、重复率或调用方指定的度量项；6 个工具全部只读，npm `dsh-sonarqube` 0.1.0 | 待测 |
 | dsh-email | [STARDUSTLC666/dsh-email](https://github.com/STARDUSTLC666/dsh-email) | 邮件工具插件：IMAP/SMTP 收/发/搜/列文件夹/附件下载（email_list/read/search/send/folders/attachment），内置 QQ/163/126/新浪/阿里/Gmail/Outlook/iCloud 预设，支持多账号与连接复用，发信默认走审批门；纯 Node 全平台 | 待测 |
 | dsh-calendar | [STARDUSTLC666/dsh-calendar](https://github.com/STARDUSTLC666/dsh-calendar) | CalDAV 日历插件：查/建/改/删/搜日程（calendar_list/create/update/delete/search），Google/iCloud/Nextcloud/自定义端点，应用专用密码 | 待测 |


### PR DESCRIPTION
Add **dsh-task-dispatcher** to PLUGINS.md (🔌 单插件).

**dsh-task-dispatcher** — TickTick (滴答清单) daily task dispatcher for DeepSeek Harness:
- interval-based pulls of today's due tasks from the 5️⃣AI list
- change-aware flomo + macOS notifications
- optional auto-execute (one headless DSH session per task)
- worker workspace selection
- dispatcher_report flomo summary tool
- web task board

npm: dsh-task-dispatcher@0.1.0 · topics: dsh-plugin / deepseek-harness / ticktick