### PR TITLE
docs: 登记 dsh-pr-checks

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -154,6 +154,7 @@
 | dsh-session-repair (Zn-Dk) | [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) | 会话日志诊断与安全修复：raw zstd/JSONL 工件校验、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录；Web「会话体检」面板 + 只读诊断工具 dsh_session_repair；npm `dsh-session-repair` 0.5.3 | 待测 |
 | dsh-rss-daily | [shangjian2023/dsh-rss-daily](https://github.com/shangjian2023/dsh-rss-daily) | 每日定时抓取 46 个精选 RSS 源，由 dsh 内已配置的模型编辑成新闻简报，经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify；错过时段自动补跑；Web 面板 + rss_daily agent 工具；npm `dsh-rss-daily` | 待测 |
 | dsh-humanize | [Guard42/dsh-humanize](https://github.com/Guard42/dsh-humanize) | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层（不写自定义会话事件） | 待测 |
+| dsh-pr-checks | [pauloapoloni/dsh-pr-checks](https://github.com/pauloapoloni/dsh-pr-checks) | 打开 PR 的 GitHub Actions 检查状态与进度：按工作区/项目分组，侧边栏底部常驻展示；dsh bundle（host + web client），npm dsh-pr-checks 0.1.1，dsh 0.1.1-rc.2 实测，MIT | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-pr-checks |
| 仓库 | https://github.com/pauloapoloni/dsh-pr-checks |
| **分类** | 🔌 Web UI 增强（预归类器命中规则：sidebar） |
| 一句话说明 | 打开 PR 的 GitHub Actions 检查状态与进度：按工作区/项目分组，侧边栏底部常驻展示；dsh bundle（host + web client），npm dsh-pr-checks 0.1.1，dsh 0.1.1-rc.2 实测，MIT |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用 `@deepseek-ai/*` 保留命名空间（本插件为无 scope 名 `dsh-pr-checks`）
- [x] 仓库已打 `dsh-plugin` topic（另有 dsh / plugin / sidebar / github-actions）
- [x] 已在 PR 页面勾选 **Allow edits from maintainers**（本 PR 已开启 maintainer 编辑权限）
- [x] 所有运行时依赖已声明（零运行时依赖）
- [x] 已按自检实测通过：`dsh plugin --profile <test> add github:pauloapoloni/dsh-pr-checks` 安装成功，bundle layer 注册正常；web widget 在浏览器实测通过（/api/pr-checks 200，无 console 错误）

## 改动内容

`PLUGINS.md` `## 🔌 单插件` 表格末尾追加一行：

```
| dsh-pr-checks | [pauloapoloni/dsh-pr-checks](https://github.com/pauloapoloni/dsh-pr-checks) | 打开 PR 的 GitHub Actions 检查状态与进度：按工作区/项目分组，侧边栏底部常驻展示；dsh bundle（host + web client），npm dsh-pr-checks 0.1.1，dsh 0.1.1-rc.2 实测，MIT | 待测 |
```

## 备注

`运行级` 列填 `待测`（以雷达自身 k8s 实测判定为准，发现后自动更新）。已打 `dsh-plugin` topic，自动收录通道同样会覆盖本插件。