### PR TITLE
docs: 登记 dsh-backup

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -161,6 +161,7 @@
 | dsh-rss-daily | [shangjian2023/dsh-rss-daily](https://github.com/shangjian2023/dsh-rss-daily) | 每日定时抓取 46 个精选 RSS 源，由 dsh 内已配置的模型编辑成新闻简报，经 webhook 推送到企业微信/Telegram/Server酱/Bark/Gotify；错过时段自动补跑；Web 面板 + rss_daily agent 工具；npm `dsh-rss-daily` | 待测 |
 | dsh-humanize | [Guard42/dsh-humanize](https://github.com/Guard42/dsh-humanize) | Humanize 模式 agent 预设：把多阶段目标编排为可恢复的 Flow（draft→check→lock→终局评审→run/resume），SHA-256 流锁身份 + HMAC 终局门禁 + 事件溯源断点续跑；15 个 flow_* 工具，纯 `node:` 内置零 npm 依赖，`dsh plugin add github:Guard42/dsh-humanize` 即装，v0.1.1 起兼容原版 harness 持久层（不写自定义会话事件） | 待测 |
 | dsh-forge | [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) | 自建 Gitea / Forgejo 的只读工具，走两者共用的 REST API：实例版本、仓库列表、议题与 PR 搜索和读取、PR diff 与变更文件，以及 Actions 运行、任务与纯文本日志；11 个工具全部只读，npm `@maxhsu/dsh-forge` 0.3.3 | 待测 |
+| dsh-backup | [xiaoyuyu6420/dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) | 一键备份与恢复 ~/.dsh 用户数据：定时自动备份（重启不中断）、sha256 完整性校验与轮换、宿主升级前自动快照、会话日志体检与定点修复（doctor）、DSH 起不来也能用的零依赖救援通道、凭据默认脱敏只存本机 vault、跨机云端同步；npm `@xiaoyuyu6420/dsh-backup` 0.9.0 | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-backup |
| 仓库 | https://github.com/xiaoyuyu6420/dsh-backup |
| 分类 | 🗂 文件数据（按 taxonomy v2 规则序自查：说明中「数据」命中第 9 位规则，且未含更高优先级类目关键词） |
| 一句话说明 | 一键备份与恢复 `~/.dsh` 用户数据：定时自动备份（重启不中断）、sha256 完整性校验与轮换、宿主升级前自动快照、会话日志体检与定点修复（doctor）、DSH 起不来也能用的零依赖救援通道、凭据默认脱敏只存本机 vault、跨机云端同步；npm `@xiaoyuyu6420/dsh-backup` 0.9.0 |

## 自检清单

- [x] package.json name 为 `@xiaoyuyu6420/dsh-backup`（作者自名 scope，未占用 `@deepseek-ai/*` 保留命名空间；与表内 @alpacachen/* 等同例）
- [x] 仓库已打 `dsh-plugin` topic
- [x] Allow edits from maintainers：PR 创建后经 API 设置 maintainerCanModify=true
- [x] 运行时依赖已声明（peerDependencies 全量声明宿主模块，engines node>=20）
- [x] 自检三步实测：
  - 隔离环境 tarball 安装 → `DSH_HOME=/tmp/x dsh --profile radar --dump-config` 组合树加载成功（exit 0，dsh-backup 条目正常入树，无 loader 报错）
  - 真实宿主验证：boot 后 webserver HTTP 200，Settings → 插件 → 备份页渲染/备份/校验全部可用（v0.9.1-pre 昨日实测，README 附截图）
  - 模板命令注：overlay 中 `name: @scope/pkg` 的值需加引号才能过 YAML 解析（不带引号会 bad indentation，建议模板顺手修一下）

## 改动内容

PLUGINS.md 🔌 单插件 表末尾追加一行。我是插件作者本人。