### PR TITLE
docs: 登记 dsh-suite

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -177,6 +177,7 @@
 | dsh-subagent-cwd | [lynx-gt/dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) | dsh-subagent-tools 加按次 cwd（子代理工作目录），附两处进程内 provider 补丁；rc.6 前台/后台 cwd 实测通过 | ✅ |
 | dsh-update-notifier | [arvin-yd/dsh-update-notifier](https://github.com/arvin-yd/dsh-update-notifier) | DSH 本体版本徽标：常驻侧边栏 Settings 行右侧，三色状态点（红=有更新/绿=最新/黄=检查中或失败），点开五态弹窗（复制更新命令/忽略/稍后/立即检查），启动 10s 首查+6h 复查；零构建、29 单测、mock-llm headless L4 实测（mainline 47f9438，证据见 [VERIFICATION.md](https://github.com/arvin-yd/dsh-update-notifier/blob/main/VERIFICATION.md)） | ✅ |
 | dsh-daily-kit | [zhouwei713/dsh-daily-kit](https://github.com/zhouwei713/dsh-daily-kit) | 日常插件集合 monorepo：16 个插件（审批门/桌面与Webhook通知/成本计量/会话导出/Ollama 本地模型/上下文水位/办公文档解析/本地文件夹索引/cron 全局调度/RSS与网页内容监控/日历/Gmail/待办/天气地点/票据识别/音视频转录）+ 4 个一键 bundle（dev-buddy/evidence-wall/inbox-zero/daily-briefing）；权限透明、读取优先、零 native 依赖，596 单测，dsh rc.6/rc.7 真实加载与 npm 安装实测通过 | ✅ |
+| dsh-suite | [STARDUSTLC666/dsh-suite](https://github.com/STARDUSTLC666/dsh-suite) | 与 18 个组件配套的组合补丁：统一注入办公流、媒体工坊、DevOps、通知与极简 PTC 预设的默认配置；组件需作为直接依赖一并安装；npm `@stardustlc/dsh-suite` | 待测 |
 
 ## 🎓 技能
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-suite |
| 仓库 | https://github.com/STARDUSTLC666/dsh-suite |
| 分类 | 🛠 基建部署（功能分类）；`PLUGINS.md` 安装形态为 🧰 插件集 |
| 一句话说明 | 与 18 个组件配套的组合补丁，统一注入办公流、媒体工坊、DevOps、通知与极简 PTC 预设的默认配置。 |

## 自检清单

- [x] npm 包使用本人可控的 `@stardustlc/dsh-suite` 命名空间，未占用官方保留 scope
- [x] 仓库已添加 `dsh-plugin` topic
- [x] `package.json` 声明 `dsh.bundle`，组件按 README 作为直接依赖一并安装
- [x] 仓库公开，包含安装、卸载、配置、兼容性与许可证说明
- [x] 仅修改 `PLUGINS.md` 的“🧰 插件集”表格，运行状态保留为维护方待测

## 自检结果

使用官方 DSH `v0.1.2-alpha.4` 源码模式，将 `dsh-suite` 与其 18 个组件安装到隔离 profile；插件树成功加载，鉴权后的 Web 页面返回 HTTP 200。

## 改动内容

在 `PLUGINS.md` 的“🧰 插件集”新增 `dsh-suite` 一行。
