### PR TITLE
docs: 登记 dsh-theme-macintosh

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -220,6 +220,7 @@
 | dsh-local-ai | [PerryLink/dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) | Ollama 本地模型接入：ollama_list/pull/remove/show 与健康检查，以官方 LlmAdapter 注册 Ollama 路由并按 model_route 规则（离线优先/长文本/隐私）分流、失败自动回退云端；/ollama 命令一键总览；npm dsh-local-ai 已发布 | 待测 |
 | dsh-cert-mcp | [PerryLink/dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp) | DSH 插件认证注册表 MCP 服务器：查询认证、列出已认证插件、读取认证规范 | 待测 |
 | dsh-wallpaper-engine | [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | 把本机 Wallpaper Engine 壁纸渲染到 DSH Web 对话界面后方：视频原生播放、Web/HTML 走 iframe、Scene 壁纸由内置纯 JS 场景渲染器输出完整场景帧（对象树/纹理/粒子/shader 效果）；iOS 液态玻璃（配色/玻璃颜色/透明度/模糊统一调节）、一级液态玻璃设置页、壁纸选择弹窗、隐藏/恢复、倍速/翻转/亮度对比度饱和度、遮挡暂停省电三档、ffmpeg 抽帧转码帧率上限、自定义壁纸上传；设置持久化到宿主端文件，npm `dsh-plugin-wallpaper-engine` 0.7.0 | 待测 |
+| dsh-theme-macintosh | [fengb3/dsh-theme-macintosh](https://github.com/fengb3/dsh-theme-macintosh) | 经典麦金塔 System 7 像素主题：ChiKareGo/Fusion Pixel 像素字体、桌面噪点画布、Finder 式会话侧栏、黑白按钮与弹窗、深浅色随官方外观切换、Kit 检视页；npm `dsh-theme-macintosh`，`dsh plugin add github:fengb3/dsh-theme-macintosh` 一键安装 | ✅(自报) |
 
 ## 📚 学习研究
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-theme-macintosh |
| 仓库 | https://github.com/fengb3/dsh-theme-macintosh |
| **分类** | 🎨 主题皮肤（预归类器命中：`python3 scripts/classify.py "dsh-theme-macintosh" "System 7 像素主题 皮肤 theme 主题"` → 🎨 主题皮肤 / theme） |
| 一句话说明 | 经典麦金塔 System 7 像素主题：ChiKareGo/Fusion Pixel 像素字体、桌面噪点画布、Finder 式会话侧栏、黑白按钮与弹窗、深浅色随官方外观切换、Kit 检视页 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用 `@deepseek-ai/*` 保留命名空间（npm 包名 `dsh-theme-macintosh`，非 scope 包，已发布 0.1.1 且 `repository` 指回仓库）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已开启允许维护者编辑（fork 设置）
- [x] 所有运行时依赖已声明（`peerDependencies`: react ^18.2.0；字体资产随包分发，无其他运行时依赖）
- [x] 已按自检三步实测通过：

自检结果：`dsh plugin --profile web add github:fengb3/dsh-theme-macintosh` 端到端实测通过——GitHub 源安装、自动注册 `dsh.profile.bundles`、重启 Web UI 后主题常驻生效（见插件仓库 README「一键安装」节）。

## 改动内容

PLUGINS.md「🔌 单插件」表末尾追加一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-theme-macintosh | [fengb3/dsh-theme-macintosh](https://github.com/fengb3/dsh-theme-macintosh) | 经典麦金塔 System 7 像素主题：ChiKareGo/Fusion Pixel 像素字体、桌面噪点画布、Finder 式会话侧栏、黑白按钮与弹窗、深浅色随官方外观切换、Kit 检视页；npm `dsh-theme-macintosh`，`dsh plugin add github:fengb3/dsh-theme-macintosh` 一键安装 | ✅(自报) |

## 备注

- 「运行级」为本机实测自报（安装级 + 视觉生效均已验证），非雷达复测，按约定标 ✅(自报)。
- 已同时投稿：awesome-dsh-plugin（PR #4346，CI 全绿）、imsai-sh 目录（PR #339）、Anil-matcha 列表（PR #128）、0xsline 精选（PR #565）。
- 仓库另带 `screenshots.json`（awesome-dsh-plugin 截图新约定）与 `docs/submission/DRAFTS.md` 投稿记录。