### PR TITLE
docs: 登记 dsh-wallpaper-engine

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -219,6 +219,7 @@
 | dshscan | [shaoshi20/dshscan](https://github.com/shaoshi20/dshscan) | DSH 插件安全审查器：风险评分/严重等级/证据/安装建议；静态+语义双通道、DSH 特有攻击面规则、npm 源码扫描与 audit、批量扫描、HTML 报告 + Web Dashboard（npm: @shaoshi/dshscan） | 待测 |
 | dsh-local-ai | [PerryLink/dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) | Ollama 本地模型接入：ollama_list/pull/remove/show 与健康检查，以官方 LlmAdapter 注册 Ollama 路由并按 model_route 规则（离线优先/长文本/隐私）分流、失败自动回退云端；/ollama 命令一键总览；npm dsh-local-ai 已发布 | 待测 |
 | dsh-cert-mcp | [PerryLink/dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp) | DSH 插件认证注册表 MCP 服务器：查询认证、列出已认证插件、读取认证规范 | 待测 |
+| dsh-wallpaper-engine | [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | 把本机 Wallpaper Engine 壁纸渲染到 DSH Web 对话界面后方：视频原生播放、Web/HTML 走 iframe、Scene 壁纸由内置纯 JS 场景渲染器输出完整场景帧（对象树/纹理/粒子/shader 效果）；iOS 液态玻璃（配色/玻璃颜色/透明度/模糊统一调节）、一级液态玻璃设置页、壁纸选择弹窗、隐藏/恢复、倍速/翻转/亮度对比度饱和度、遮挡暂停省电三档、ffmpeg 抽帧转码帧率上限、自定义壁纸上传；设置持久化到宿主端文件，npm `dsh-plugin-wallpaper-engine` 0.7.0 | 待测 |
 
 ## 📚 学习研究
 


### PR DESCRIPTION
<!-- 插件登记 PR 模板 -->

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-wallpaper-engine |
| 仓库 | https://github.com/elysia395/dsh-wallpaper-engine |
| **分类** | 🎨 主题皮肤 |
| 一句话说明 | 把本机 Wallpaper Engine 壁纸渲染到 DSH Web 对话界面后方：Video（mp4）原生播放、Web/HTML 走 iframe、Scene 壁纸由内置纯 JS 场景渲染器输出完整场景帧（对象树/纹理/粒子/shader 效果）；iOS 液态玻璃效果（配色/玻璃颜色/透明度/模糊统一调节）、一级液态玻璃设置页、壁纸选择弹窗、隐藏/恢复、倍速/翻转/亮度对比度饱和度、遮挡暂停省电三档、ffmpeg 抽帧转码帧率上限、自定义壁纸上传；设置持久化到宿主端文件。 |

> 分类依据：已运行仓库预归类器 `python3 scripts/classify.py "dsh-wallpaper-engine" "<描述>"`，输出「建议分类: 🎨 主题皮肤，命中规则: 壁纸」。

## 自检清单（提交前逐项确认）

- [x] package.json `name` 为 `dsh-plugin-wallpaper-engine`（npm 公开包 0.7.0，未占用 `@deepseek-ai/*` 保留命名空间）
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已允许维护者修改（本 PR 创建时 `maintainer_can_modify: true`）
- [x] 运行时依赖已声明（`dependencies`: jpeg-js ^0.4.4、@shaderfrog/glsl-parser ^7.0.1）
- [x] README 已说明安装/卸载与功能（含[小白向使用指南](https://github.com/elysia395/dsh-wallpaper-engine/blob/main/README.beginner.md)），MIT LICENSE
- [ ] 加载级实测（自检三步）：本机暂未安装 dsh CLI headless 环境，未跑通加载实测；运行级如实标注「待测」，欢迎雷达实测跟踪

## 改动内容

PLUGINS.md「🔌 单插件」表末尾追加一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-wallpaper-engine | [elysia395/dsh-wallpaper-engine](https://github.com/elysia395/dsh-wallpaper-engine) | 把本机 Wallpaper Engine 壁纸渲染到 DSH Web 对话界面后方：视频原生播放、Web/HTML 走 iframe、Scene 壁纸由内置纯 JS 场景渲染器输出完整场景帧（对象树/纹理/粒子/shader 效果）；iOS 液态玻璃（配色/玻璃颜色/透明度/模糊统一调节）、一级液态玻璃设置页、壁纸选择弹窗、隐藏/恢复、倍速/翻转/亮度对比度饱和度、遮挡暂停省电三档、ffmpeg 抽帧转码帧率上限、自定义壁纸上传；设置持久化到宿主端文件，npm `dsh-plugin-wallpaper-engine` 0.7.0 | 待测 |

## 备注

- 分类备注：插件除壁纸渲染外，还注册了一级液态玻璃设置页、壁纸选择弹窗、隐藏/恢复管理等**新面板与新交互**——按 docs/CATALOGING.md 边界条款（「增改功能（新面板/新交互）→ Web UI 增强」），若维护者认为更符合边界归属，可改归「🔌 Web UI 增强」，按主题皮肤登记亦可接受。
- 当前版本 0.7.0，Windows 为主（支持 WSL 下探测 `/mnt/<盘符>` Steam 库）；README 含动图演示与场景渲染器原理说明。
- 希望雷达重点跟踪：Web/HTML 壁纸 iframe 沙箱、场景渲染器在低配机器的缓存命中表现、Edge 兼容渲染开关。
