### PR TITLE
docs: 登记 dsh-zhipu-toolkit

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -15,6 +15,7 @@
 | dsh-worktree | [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) | DSH Web 极简 Git worktree 管理：一个按钮和一个对话框创建任务分支 worktree，并直接打开为 DSH Workspace；npm `@alpacachen/dsh-simple-worktree` 1.0.2 | 待测 |
 | dsh-session-pin | [PerryLink/dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) | 会话与工作区置顶（双面 host+client）：行级图钉与换色、会话头开关、已置顶面板、持久化 settings 命名空间；0.4.0 再加会话导航组织器——Pin 分组（boards）、标签与保存视图、会话健康摘要（只读脱敏）与 /goto 模糊跳转；全部浏览器本地零网络 | 待测 |
 | dsh-session-explorer | [Zn-Dk/dsh-session-explorer](https://github.com/Zn-Dk/dsh-session-explorer) | 会话消息级全文检索浏览器：FTS5 trigram 按消息检索（用户/助手/系统注入/工具，可按类型筛选），fork/续接会话结果自动去重，只读上下文预览自动滚动定位、一键跳转真实会话，增量/全量重建索引 + 健康检查，中英双语跟随 Host locale | 待测 |
+| dsh-zhipu-toolkit | [Zn-Dk/dsh-zhipu-toolkit](https://github.com/Zn-Dk/dsh-zhipu-toolkit) | 智谱 BigModel GLM 双端点模型目录（Coding Plan 与普通 API），实时模型发现、实测思考档位映射，可视化设置卡片管理 Key/端点/默认推理档，本地 API Key 支持存入 DSH 凭证库；npm `dsh-zhipu-toolkit`@0.1.0 | 待测 |
 | dsh-agentfuse-plugin | [MkaliezZ/dsh-agentfuse-plugin](https://github.com/MkaliezZ/dsh-agentfuse-plugin) | 确定性 fail-closed 工具调用授权门：allow/block/ask 策略门 + 审批链延后 + agentfuse-evidence-schema 证据；配 dsh-policy-test 闭环回归；已获本雷达运行级 [可用] 判定 | ✅ |
 | dsh-evidence-task-board | [MkaliezZ/dsh-evidence-task-board](https://github.com/MkaliezZ/dsh-evidence-task-board) | 持久化确定性任务状态原语（创建/状态/证据转移）；npm 包 @mkaliezz/dsh-task-board | 待测 |
 | dsh-test-normalizer | [MkaliezZ/dsh-test-normalizer](https://github.com/MkaliezZ/dsh-test-normalizer) | pytest / Vitest / Jest / Cargo 测试结果归一化为稳定结构；npm 包 @mkaliezz/dsh-test-runner | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-zhipu-toolkit |
| 仓库 | https://github.com/Zn-Dk/dsh-zhipu-toolkit |
| **分类** | 🛠 基建部署 |
| 一句话说明 | 智谱 BigModel GLM 双端点模型目录（Coding Plan 与普通 API），实时模型发现、实测思考档位映射，可视化设置卡片管理 Key/端点/默认推理档，本地 API Key 支持存入 DSH 凭证库。 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 未占用保留命名空间：npm 包名为无 scope 的 `dsh-zhipu-toolkit`（官方源已上架 @0.1.0，未占用 `@deepseek-ai/*`）
- [x] 仓库已打 `dsh-plugin` topic
- [x] Allow edits from maintainers：本 PR 创建时已通过 API 设置 `maintainer_can_modify: true`
- [x] 所有运行时依赖已在 package.json dependencies 中声明（随 npm 包发布）
- [x] 已按自检三步实测通过：

**自检结果（真实证据）**：插件在本机 dsh web 以 `link:` 模式连续运行多日、无报错；模拟宿主加载通过；80/80 vitest 全部通过。

## 改动内容

PLUGINS.md「🔌 单插件」表格在 Zn-Dk 同作者行（dsh-session-explorer）后追加一行：

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-zhipu-toolkit | [Zn-Dk/dsh-zhipu-toolkit](https://github.com/Zn-Dk/dsh-zhipu-toolkit) | 智谱 BigModel GLM 双端点模型目录（Coding Plan 与普通 API），实时模型发现、实测思考档位映射，可视化设置卡片管理 Key/端点/默认推理档，本地 API Key 支持存入 DSH 凭证库 | 待测 |

## 备注

- 运行级如实填「待测」，未自封 ✅。
- 分类说明：预归类器输出「🤖 Agent 能力」，但命中关键词为 `plan`（来自描述中的 "Coding Plan"，疑似误命中）；按 docs/CATALOGING.md 边界归属「接入外部模型 → 基建部署」，故填 🛠 基建部署，请维护者复核。