### PR TITLE
docs: 登记 dsh-xiaomi-tts

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -10,6 +10,7 @@
 
 | 插件 | 仓库 | 说明 | 运行级 |
 |---|---|---|---|
+| dsh-xiaomi-tts | [ppy-web/dsh-plugin-xiaomi-mimo-tts](https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts) | Xiaomi MiMo TTS 语音朗读：预置/自定义音色、PCM 流式播放、MP3/WAV 完整音频与浏览器语音双向兜底；支持 MiMo 优先/本地优先/关闭本地语音 | 待测 |
 | dsh-wps | [zhengjy01/dsh-wps](https://github.com/zhengjy01/dsh-wps) | WPS / 金山文档云文档集成（官方 SkillHub MCP，mcp__wps__* 工具） | agent |
 | dsh-vercel-mcp | [zhengjy01/dsh-vercel-mcp](https://github.com/zhengjy01/dsh-vercel-mcp) | Vercel MCP connection for DSH: official OAuth 2.0 client flow against mcp.vercel.com; Vercel platform tools under mcp__vercel__* | 待测 |
 | dsh-worktree | [alpacachen/dsh-worktree](https://github.com/alpacachen/dsh-worktree) | DSH Web 极简 Git worktree 管理：一个按钮和一个对话框创建任务分支 worktree，并直接打开为 DSH Workspace；npm `@alpacachen/dsh-simple-worktree` 1.0.2 | 待测 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | `dsh-xiaomi-tts` |
| 仓库 | https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts |
| 分类 | 🔌 单插件 |
| 一句话说明 | Xiaomi MiMo TTS 语音朗读：预置/自定义音色、PCM 流式播放、MP3/WAV 完整音频与浏览器语音双向兜底；支持 MiMo 优先/本地优先/关闭本地语音 |

## 自检结果

- 仓库公开可访问，已添加 `dsh-plugin` topic。
- `package.json` 包名为 `dsh-xiaomi-tts`，提供 `main` 与 `exports`，MIT 许可证。
- README 已说明 DSH 版本要求、安装、卸载、配置、隐私、故障排查和开发测试方式。
- `pnpm typecheck`：通过。
- `pnpm test`：55/55 通过。
- `pnpm pack:check`：通过。
- 已勾选/同意 Allow edits from maintainers；欢迎维护者按最新目录结构调整本条目。

## 改动内容

| 插件 | 仓库 | 说明 |
|---|---|---|
| `dsh-xiaomi-tts` | https://github.com/ppy-web/dsh-plugin-xiaomi-mimo-tts | 登记 Xiaomi MiMo TTS Web 语音朗读插件，运行级状态暂标为“待测”。 |

## 备注

本 PR 只登记插件，不代表 DSH 官方背书，也不预先声明 Radar 运行级兼容结果；欢迎按 Radar 流程进一步测试。