### PR TITLE
docs: 登记 dsh-alpha

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -180,6 +180,7 @@
 | dsh-aliyun-mcp | [zhengjy01/dsh-aliyun-mcp](https://github.com/zhengjy01/dsh-aliyun-mcp) | 阿里云 OpenAPI MCP 连接：静态凭证 + 官方 MCP Proxy，把 ECS / OSS / 域名 / DNS / 函数计算等 OpenAPI 暴露为 mcp__aliyun__* 工具 | 待测 |
 | dsh-wallpaper_share | [YRN-playmaker/dsh-wallpaper_share](https://github.com/YRN-playmaker/dsh-wallpaper_share) | Wallpaper Engine 壁纸同步为 DSH Web 背景（本地桥接）：预览/捕获/完整三档渲染、显示器锁定、本地与市场壁纸库（标题搜索、分页）、专注透镜与眼动追踪、沉浸模式、DWP 挂载；Windows 应用启动器支持直链与 139 网盘分享、加密 zip/7z 解包与一键启动（每次弹确认） | 待测 |
 | dsh-insight-tree | [xingzhen199186/dsh-insight-tree](https://github.com/xingzhen199186/dsh-insight-tree) | DSH 运行可观测与插件运维面板：Profile 插件树、Loader 真实 fiber 状态、能力/依赖/兼容性、本轮会话插件活动与上游来源/版本核验；一键关闭/启用/更新/卸载 + 独立启动失败诊断页（DSH 未运行也可单独启动）；npm `dsh-insight-tree`@0.1.2，MIT | 待测 |
+| dsh-alpha | [songofhawk/dsh-alpha](https://github.com/songofhawk/dsh-alpha) | 多机多 Agent 编排与控制平台：从一个 DSH 会话发现跨设备 Agent 与工作区，按机器、仓库、能力和负载路由任务，统一回传进度、审批与结果；支持断线恢复，npm `dsh-alpha` | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-alpha |
| 仓库 | https://github.com/songofhawk/dsh-alpha |
| **分类** | 🤖 Agent 能力 |
| 一句话说明 | 多机多 Agent 编排与控制平台：从一个 DSH 会话发现跨设备 Agent 与工作区，按机器、仓库、能力和负载路由任务，统一回传进度、审批与结果，并支持断线恢复。 |

## 自检清单

- [x] 根包名为本人控制的非 scope npm 包 `dsh-alpha`，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已打 `dsh-plugin` topic
- [x] 已允许维护者编辑此 PR
- [x] 所有运行时依赖已在 `dependencies` / `peerDependencies` 中声明
- [ ] 尚未在 Radar 的指定 headless 环境完成运行级加载，因此目录状态如实标为「待测」
- [x] 项目根目录自动化测试 184/184 通过；`npm pack --dry-run` 通过（这两项不替代 Radar 运行级测试）

## 改动内容

| 插件 | 仓库 | 说明 | 运行级 |
|---|---|---|---|
| dsh-alpha | [songofhawk/dsh-alpha](https://github.com/songofhawk/dsh-alpha) | 多机多 Agent 编排与控制平台：从一个 DSH 会话发现跨设备 Agent 与工作区，按机器、仓库、能力和负载路由任务，统一回传进度、审批与结果；支持断线恢复，npm `dsh-alpha` | 待测 |

## 备注

根目录 `package.json` 提供 `dsh.bundle` 清单；提交分支已 rebase 到最新 `main`，本 PR 仅向 `PLUGINS.md` 增加一行。请由 Radar 后续运行级流水线给出兼容性结论。