### PR TITLE
docs: 登记 dsh-insight-tree

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -179,6 +179,7 @@
 | dsh-feishu-mcp | [zhengjy01/dsh-feishu-mcp](https://github.com/zhengjy01/dsh-feishu-mcp) | 飞书（Lark）OpenAPI MCP 连接：桥接官方 @larksuiteoapi/lark-mcp，把 IM / 多维表格 / 云文档 / 日历 / 云盘 API 暴露为 mcp__feishu__* 工具，支持用户令牌 OAuth | 待测 |
 | dsh-aliyun-mcp | [zhengjy01/dsh-aliyun-mcp](https://github.com/zhengjy01/dsh-aliyun-mcp) | 阿里云 OpenAPI MCP 连接：静态凭证 + 官方 MCP Proxy，把 ECS / OSS / 域名 / DNS / 函数计算等 OpenAPI 暴露为 mcp__aliyun__* 工具 | 待测 |
 | dsh-wallpaper_share | [YRN-playmaker/dsh-wallpaper_share](https://github.com/YRN-playmaker/dsh-wallpaper_share) | Wallpaper Engine 壁纸同步为 DSH Web 背景（本地桥接）：预览/捕获/完整三档渲染、显示器锁定、本地与市场壁纸库（标题搜索、分页）、专注透镜与眼动追踪、沉浸模式、DWP 挂载；Windows 应用启动器支持直链与 139 网盘分享、加密 zip/7z 解包与一键启动（每次弹确认） | 待测 |
+| dsh-insight-tree | [xingzhen199186/dsh-insight-tree](https://github.com/xingzhen199186/dsh-insight-tree) | DSH 运行可观测与插件运维面板：Profile 插件树、Loader 真实 fiber 状态、能力/依赖/兼容性、本轮会话插件活动与上游来源/版本核验；一键关闭/启用/更新/卸载 + 独立启动失败诊断页（DSH 未运行也可单独启动）；npm `dsh-insight-tree`@0.1.2，MIT | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
> 标题格式：`docs: 登记 dsh-insight-tree`（title 已按此填写）

## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-insight-tree |
| 仓库 | https://github.com/xingzhen199186/dsh-insight-tree |
| **分类** | 🛒 市场与管理（用官方预归类器验证：`python scripts/classify.py "dsh-insight-tree" "DSH 运行可观测与插件运维面板：插件树、Loader 真实状态、上游来源与版本核验，插件装卸载与更新管理，独立启动诊断页"` → `建议分类: 🛒 市场与管理`，命中规则 `卸载`） |
| 一句话说明 | DSH 运行可观测与插件运维面板：Profile 插件树、Loader 真实 fiber 状态、能力/依赖/兼容性、本轮会话插件活动与上游来源/版本核验；一键关闭/启用/更新/卸载 + 独立启动失败诊断页（DSH 未运行也可单独启动） |

## 自检清单

- [ ] package.json `name` 使用 `@dsh-external/*` scope —— **本包为无 scope 的 `dsh-insight-tree`**（未占用 `@deepseek-ai/*` 保留命名空间），npm 已发布 `0.1.2`；如需改成 `@dsh-external/*` 请说一声，我会同步发新包
- [x] 仓库已打 `dsh-plugin` topic（另有 `dsh` / `deepseek-harness` / `cordis-plugin` 等）
- [ ] Allow edits from maintainers —— 已请求，若未生效请告知，我可以随时 rebase
- [x] 所有运行时依赖已声明（runtime：`js-yaml` / `semver` / `zod`；`@deepseek-ai/*` 一律走 `peerDependencies`，可选 peer 缺失时自动降级）
- [x] 已按加载级自检实测通过：

### 自检结果（隔离 DSH_HOME 实测，加载级 + 运行级）

```text
$ dsh plugin --profile web add dsh-insight-tree        # 从 npm 装 0.1.2
$ dsh --profile web --port 3201 --no-open              # 启动成功，无报错
$ GET http://127.0.0.1:3201/dsh-insight-tree           # 插件自身路由
  → HTTP 200
    schemaVersion=3  versionSource=installed  ruleVersion=1  reportStatus=ready
    dsh-insight-tree: version=0.1.2  status=active  fiberPhase=active
```

即：插件在真实 host 里装载成功，`ctx.loader` 快照显示自身 `fiberPhase=active`（该隔离 profile 共 149 条 Loader 条目）。宿主 DSH `0.1.2-rc.1`，Node v24.14.1。

## 改动内容（PLUGINS.md 追加的行，已直接落在「🔌 单插件」表尾）

| 插件 | 仓库 | 说明 |
|---|---|---|
| dsh-insight-tree | https://github.com/xingzhen199186/dsh-insight-tree | DSH 运行可观测与插件运维面板：插件树、Loader 真实状态、上游来源与版本核验、插件装卸载与更新、独立启动诊断页；npm `dsh-insight-tree`@0.1.2 |

## 备注

- npm：`dsh-insight-tree@0.1.2`（latest），GitHub tag `v0.1.2`，MIT
- 已在 1024 Store（`catalog/plugins/xingzhen199186--dsh-insight-tree.json`）、awesome-dsh-plugin、Dominic789654 等目录登记
- 想被雷达重点跟踪的维度：独立诊断页在 DSH 未运行时的可用性；`ctx.loader` fiber 状态映射（结构行排除逻辑）；上游版本适配判定