### PR TITLE
docs: 登记 dsh-autotier

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -181,6 +181,7 @@
 | dsh-wallpaper_share | [YRN-playmaker/dsh-wallpaper_share](https://github.com/YRN-playmaker/dsh-wallpaper_share) | Wallpaper Engine 壁纸同步为 DSH Web 背景（本地桥接）：预览/捕获/完整三档渲染、显示器锁定、本地与市场壁纸库（标题搜索、分页）、专注透镜与眼动追踪、沉浸模式、DWP 挂载；Windows 应用启动器支持直链与 139 网盘分享、加密 zip/7z 解包与一键启动（每次弹确认） | 待测 |
 | dsh-insight-tree | [xingzhen199186/dsh-insight-tree](https://github.com/xingzhen199186/dsh-insight-tree) | DSH 运行可观测与插件运维面板：Profile 插件树、Loader 真实 fiber 状态、能力/依赖/兼容性、本轮会话插件活动与上游来源/版本核验；一键关闭/启用/更新/卸载 + 独立启动失败诊断页（DSH 未运行也可单独启动）；npm `dsh-insight-tree`@0.1.2，MIT | 待测 |
 | dsh-alpha | [songofhawk/dsh-alpha](https://github.com/songofhawk/dsh-alpha) | 多机多 Agent 编排与控制平台：从一个 DSH 会话发现跨设备 Agent 与工作区，按机器、仓库、能力和负载路由任务，统一回传进度、审批与结果；支持断线恢复，npm `dsh-alpha` | 待测 |
+| dsh-autotier | [PerryLink/dsh-autotier](https://github.com/PerryLink/dsh-autotier) | 自动模型分层路由：一条用户指令进、一条分层决策出——复杂意图由强档规划、廉价档执行，确定性护栏 + TTL 升级回退，无需手动切换模型；`dsh.bundle.patch` 可安装，1024 商店渠道 `dsh1024 plugin --profile web add dsh-autotier` | 待测 |
 ## 🧰 插件集
 
 | 插件 | 仓库 | 说明 | 运行级 |


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-autotier |
| 仓库 | https://github.com/PerryLink/dsh-autotier |
| **分类** | 🔌 单插件 |
| 一句话说明 | Automatic model-tier routing for DeepSeek Harness: one user instruction enters, one tier decision comes out — no manual model switching. |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用作者自有 `@perrylink/*` scope，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已打 `dsh-plugin` topic（如需核实请以仓库页 Topics 为准）
- [x] 已勾选 Allow edits from maintainers
- [x] 运行时依赖已声明（`dependencies`/`peerDependencies`）
- [x] 自测结果：`dsh --profile headless --patch <(printf -- '- insert:\n    - id: github:PerryLink/dsh-autotier\n      name: @perrylink/dsh-autotier\n') "hi"` 加载级通过，无报错

## 改动内容

PLUGINS.md `## 🔌 单插件` 表尾追加 1 行：

```
| dsh-autotier | [PerryLink/dsh-autotier](https://github.com/PerryLink/dsh-autotier) | 自动模型分层路由：一条用户指令进、一条分层决策出——复杂意图由强档规划、廉价档执行，确定性护栏 + TTL 升级回退，无需手动切换模型；`dsh.bundle.patch` 可安装，1024 商店渠道 `dsh1024 plugin --profile web add dsh-autotier` | 待测 |
```

## 备注

bundle 声明 `dsh.bundle.patch=./cordis.patch.yml` 且 patch 已提交；运行级请按雷达管道实测结果回填。
