### PR TITLE
docs: 登记 dsh-plugin-upgrade-015

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -202,6 +202,7 @@
 | dsh-plugin-guide | [PerryLink/dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) | DSH 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能（bundle 可安装，注册 ctx.skills 技能） | 待测 |
 | dsh-chinese-traditional-wisdom-skill | [dhicoc/dsh-chinese-traditional-wisdom-skill](https://github.com/dhicoc/dsh-chinese-traditional-wisdom-skill) | 中华传统智慧（玄枢）AI Agent 技能包：八字/紫微/六爻/梅花/奇门/风水/五运六气/体质全融合，本地确定性引擎 + 可视化 Dashboard；dsh.bundle manifest 可安装 | ✅ |
 | dsh-skill-pack-security | [PerryLink/dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) | 安全审计方法论技能包：八个 agent 技能（密钥扫描、依赖审计、供应链评审、提示注入审查、审计总编排、威胁建模、漏洞情报、事件响应），中英双版本；`dsh plugin add @perrylink/dsh-skill-pack-security-provider` 一键挂载 | 待测 |
+| dsh-plugin-upgrade-015 | [PerryLink/dsh-plugin-upgrade-015](https://github.com/PerryLink/dsh-plugin-upgrade-015) | 合并双版本支线的插件升级技能：0.1.3-alpha.1 → 0.1.5-rc.1 两条闭合支线（leg A/B），带证据的版本卡 + 零依赖 20 接缝扫描器（bundle 技能 + npx CLI），防止客户端半静默不挂载被误判为「类型检查绿」；官方唯一仓库，取代已 404 的 dsh-plugin-upgrade / dsh-plugin-upgrade-rc1 两个旧版本锁包 | 待测 |
 
 ## 📡 远程渠道
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-plugin-upgrade-015 |
| 仓库 | https://github.com/PerryLink/dsh-plugin-upgrade-015 |
| **分类** | 🎓 技能 |
| 一句话说明 | 合并双版本支线的插件升级技能：0.1.3-alpha.1 → 0.1.5-rc.1 两条闭合支线（leg A/B），带证据的版本卡 + 零依赖 20 接缝扫描器（bundle 技能 + npx CLI），防止客户端半静默不挂载被误判为「类型检查绿」 |

## 自检清单（提交前逐项确认）

- [x] package.json `name` 使用作者自有 `@perrylink/*` scope，未占用 `@deepseek-ai/*` 保留命名空间
- [x] 仓库已打 `dsh-plugin` topic（如需核实请以仓库页 Topics 为准）
- [x] 已勾选 Allow edits from maintainers
- [x] 运行时依赖已声明（`dependencies`/`peerDependencies`）
- [x] 自测结果：`dsh --profile headless --patch <(printf -- '- insert:\n    - id: github:PerryLink/dsh-plugin-upgrade-015\n      name: @perrylink/dsh-plugin-upgrade-015\n') "hi"` 加载级通过，无报错

## 改动内容

PLUGINS.md `## 🎓 技能` 表尾追加 1 行：

```
| dsh-plugin-upgrade-015 | [PerryLink/dsh-plugin-upgrade-015](https://github.com/PerryLink/dsh-plugin-upgrade-015) | 合并双版本支线的插件升级技能：0.1.3-alpha.1 → 0.1.5-rc.1 两条闭合支线（leg A/B），带证据的版本卡 + 零依赖 20 接缝扫描器（bundle 技能 + npx CLI），防止客户端半静默不挂载被误判为「类型检查绿」；官方唯一仓库，取代已 404 的 dsh-plugin-upgrade / dsh-plugin-upgrade-rc1 两个旧版本锁包 | 待测 |
```

## 备注

取代旧包，旧包仓库已 404。
